### PR TITLE
Enable case insensitive search to get more reliable search results

### DIFF
--- a/wofi-emoji
+++ b/wofi-emoji
@@ -1,5 +1,5 @@
 #!/bin/bash
-sed '1,/^### DATA ###$/d' $0 | wofi --show dmenu | cut -d ' ' -f 1 | tr -d '\n' | wl-copy
+sed '1,/^### DATA ###$/d' $0 | wofi --show dmenu -i | cut -d ' ' -f 1 | tr -d '\n' | wl-copy
 exit
 ### DATA ###
 😀 grinning face
@@ -1807,3 +1807,4 @@ exit
 🏴󠁧󠁢󠁥󠁮󠁧󠁿 flag: England
 🏴󠁧󠁢󠁳󠁣󠁴󠁿 flag: Scotland
 🏴󠁧󠁢󠁷󠁬󠁳󠁿 flag: Wales
+


### PR DESCRIPTION
This PR enables case insensitive search in wofi to get more reliable search results.
The tags of most emojis are lowercase, with some exceptions. With the `-i`/`--insensitive` flag wofi ignores case.

Example: `🌍 globe showing Europe-Africa`
Without the flag, typing `europe` leads to no result.