### PR TITLE
Fix build script sed regex

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-sed -i '/### DATA ###/q' wofi-emoji
+sed -i '/^### DATA ###$/q' wofi-emoji
 
 curl https://raw.githubusercontent.com/github/gemoji/master/db/emoji.json \
   | jq  --raw-output '.[] | (.emoji + " " + .description)' \


### PR DESCRIPTION
The regex was matching the first instance of `### DATA ###` which was in the sed command. This fix matches the line right above the emojis which is what it's supposed to match on.