### PR TITLE
Replace underscores with spaces.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 sed -i '/^### DATA ###$/q' wofi-emoji
 
-curl https://raw.githubusercontent.com/muan/emojilib/main/dist/emoji-en-US.json \
+curl https://raw.githubusercontent.com/muan/emojilib/v3.0.6/dist/emoji-en-US.json \
   | jq --raw-output '. | to_entries | .[] | .key + " " + (.value | join(" ") | sub("_"; " "; "g"))' \
   >> wofi-emoji

--- a/build.sh
+++ b/build.sh
@@ -2,5 +2,5 @@
 sed -i '/^### DATA ###$/q' wofi-emoji
 
 curl https://raw.githubusercontent.com/muan/emojilib/main/dist/emoji-en-US.json \
-  | jq  --raw-output '. | to_entries | .[] | .key + " " + (.value | join(" "))' \
+  | jq --raw-output '. | to_entries | .[] | .key + " " + (.value | join(" ") | sub("_"; " "; "g"))' \
   >> wofi-emoji

--- a/wofi-emoji
+++ b/wofi-emoji
@@ -14,7 +14,7 @@ exit
 🙃 upside down face face flipped silly smile
 😉 winking face face happy mischievous secret ;) smile eye
 😊 smiling face with smiling eyes face smile happy flushed crush embarrassed shy joy
-😇 smiling face with halo face angel heaven halo innocent
+😇 smiling face with halo face angel heaven halo
 🥰 smiling face with hearts face love like affection valentines infatuation crush hearts adore
 😍 smiling face with heart eyes face love like affection valentines infatuation crush heart
 🤩 star struck face smile starry eyes grinning

--- a/wofi-emoji
+++ b/wofi-emoji
@@ -2,195 +2,195 @@
 sed '1,/^### DATA ###$/d' $0 | wofi --show dmenu -i | cut -d ' ' -f 1 | tr -d '\n' | wtype -
 exit
 ### DATA ###
-😀 grinning_face face smile happy joy :D grin
-😃 grinning_face_with_big_eyes face happy joy haha :D :) smile funny
-😄 grinning_face_with_smiling_eyes face happy joy funny haha laugh like :D :) smile
-😁 beaming_face_with_smiling_eyes face happy smile joy kawaii
-😆 grinning_squinting_face happy joy lol satisfied haha face glad XD laugh
-😅 grinning_face_with_sweat face hot happy laugh sweat smile relief
-🤣 rolling_on_the_floor_laughing face rolling floor laughing lol haha rofl
-😂 face_with_tears_of_joy face cry tears weep happy happytears haha
-🙂 slightly_smiling_face face smile
-🙃 upside_down_face face flipped silly smile
-😉 winking_face face happy mischievous secret ;) smile eye
-😊 smiling_face_with_smiling_eyes face smile happy flushed crush embarrassed shy joy
-😇 smiling_face_with_halo face angel heaven halo innocent
-🥰 smiling_face_with_hearts face love like affection valentines infatuation crush hearts adore
-😍 smiling_face_with_heart_eyes face love like affection valentines infatuation crush heart
-🤩 star_struck face smile starry eyes grinning
-😘 face_blowing_a_kiss face love like affection valentines infatuation kiss
-😗 kissing_face love like face 3 valentines infatuation kiss
-☺️ smiling_face face blush massage happiness
-😚 kissing_face_with_closed_eyes face love like affection valentines infatuation kiss
-😙 kissing_face_with_smiling_eyes face affection valentines infatuation kiss
-😋 face_savoring_food happy joy tongue smile face silly yummy nom delicious savouring
-😛 face_with_tongue face prank childish playful mischievous smile tongue
-😜 winking_face_with_tongue face prank childish playful mischievous smile wink tongue
-🤪 zany_face face goofy crazy
-😝 squinting_face_with_tongue face prank playful mischievous smile tongue
-🤑 money_mouth_face face rich dollar money
-🤗 hugging_face face smile hug
-🤭 face_with_hand_over_mouth face whoops shock surprise
-🤫 shushing_face face quiet shhh
-🤔 thinking_face face hmmm think consider
-🤐 zipper_mouth_face face sealed zipper secret
-🤨 face_with_raised_eyebrow face distrust scepticism disapproval disbelief surprise
-😐 neutral_face indifference meh :| neutral
-😑 expressionless_face face indifferent -_- meh deadpan
-😶 face_without_mouth face hellokitty
-😏 smirking_face face smile mean prank smug sarcasm
-😒 unamused_face indifference bored straight face serious sarcasm unimpressed skeptical dubious side_eye
-🙄 face_with_rolling_eyes face eyeroll frustrated
-😬 grimacing_face face grimace teeth
-🤥 lying_face face lie pinocchio
-😌 relieved_face face relaxed phew massage happiness
-😔 pensive_face face sad depressed upset
-😪 sleepy_face face tired rest nap
-🤤 drooling_face face
-😴 sleeping_face face tired sleepy night zzz
-😷 face_with_medical_mask face sick ill disease
-🤒 face_with_thermometer sick temperature thermometer cold fever
-🤕 face_with_head_bandage injured clumsy bandage hurt
-🤢 nauseated_face face vomit gross green sick throw up ill
-🤮 face_vomiting face sick
-🤧 sneezing_face face gesundheit sneeze sick allergy
-🥵 hot_face face feverish heat red sweating
-🥶 cold_face face blue freezing frozen frostbite icicles
-🥴 woozy_face face dizzy intoxicated tipsy wavy
-😵 dizzy_face spent unconscious xox dizzy
-🤯 exploding_head face shocked mind blown
-🤠 cowboy_hat_face face cowgirl hat
-🥳 partying_face face celebration woohoo
-😎 smiling_face_with_sunglasses face cool smile summer beach sunglass
-🤓 nerd_face face nerdy geek dork
-🧐 face_with_monocle face stuffy wealthy
-😕 confused_face face indifference huh weird hmmm :/
-😟 worried_face face concern nervous :(
-🙁 slightly_frowning_face face frowning disappointed sad upset
-☹️ frowning_face face sad upset frown
-😮 face_with_open_mouth face surprise impressed wow whoa :O
-😯 hushed_face face woo shh
-😲 astonished_face face xox surprised poisoned
-😳 flushed_face face blush shy flattered
-🥺 pleading_face face begging mercy
-😦 frowning_face_with_open_mouth face aw what
-😧 anguished_face face stunned nervous
-😨 fearful_face face scared terrified nervous oops huh
-😰 anxious_face_with_sweat face nervous sweat
-😥 sad_but_relieved_face face phew sweat nervous
-😢 crying_face face tears sad depressed upset :'(
-😭 loudly_crying_face face cry tears sad upset depressed
-😱 face_screaming_in_fear face munch scared omg
-😖 confounded_face face confused sick unwell oops :S
-😣 persevering_face face sick no upset oops
-😞 disappointed_face face sad upset depressed :(
-😓 downcast_face_with_sweat face hot sad tired exercise
-😩 weary_face face tired sleepy sad frustrated upset
-😫 tired_face sick whine upset frustrated
-🥱 yawning_face tired sleepy
-😤 face_with_steam_from_nose face gas phew proud pride
-😡 pouting_face angry mad hate despise
-😠 angry_face mad face annoyed frustrated
-🤬 face_with_symbols_on_mouth face swearing cursing cussing profanity expletive
-😈 smiling_face_with_horns devil horns
-👿 angry_face_with_horns devil angry horns
+😀 grinning face face smile happy joy :D grin
+😃 grinning face with big eyes face happy joy haha :D :) smile funny
+😄 grinning face with smiling eyes face happy joy funny haha laugh like :D :) smile
+😁 beaming face with smiling eyes face happy smile joy kawaii
+😆 grinning squinting face happy joy lol satisfied haha face glad XD laugh
+😅 grinning face with sweat face hot happy laugh sweat smile relief
+🤣 rolling on the floor laughing face rolling floor laughing lol haha rofl
+😂 face with tears of joy face cry tears weep happy happytears haha
+🙂 slightly smiling face face smile
+🙃 upside down face face flipped silly smile
+😉 winking face face happy mischievous secret ;) smile eye
+😊 smiling face with smiling eyes face smile happy flushed crush embarrassed shy joy
+😇 smiling face with halo face angel heaven halo innocent
+🥰 smiling face with hearts face love like affection valentines infatuation crush hearts adore
+😍 smiling face with heart eyes face love like affection valentines infatuation crush heart
+🤩 star struck face smile starry eyes grinning
+😘 face blowing a kiss face love like affection valentines infatuation kiss
+😗 kissing face love like face 3 valentines infatuation kiss
+☺️ smiling face face blush massage happiness
+😚 kissing face with closed eyes face love like affection valentines infatuation kiss
+😙 kissing face with smiling eyes face affection valentines infatuation kiss
+😋 face savoring food happy joy tongue smile face silly yummy nom delicious savouring
+😛 face with tongue face prank childish playful mischievous smile tongue
+😜 winking face with tongue face prank childish playful mischievous smile wink tongue
+🤪 zany face face goofy crazy
+😝 squinting face with tongue face prank playful mischievous smile tongue
+🤑 money mouth face face rich dollar money
+🤗 hugging face face smile hug
+🤭 face with hand over mouth face whoops shock surprise
+🤫 shushing face face quiet shhh
+🤔 thinking face face hmmm think consider
+🤐 zipper mouth face face sealed zipper secret
+🤨 face with raised eyebrow face distrust scepticism disapproval disbelief surprise
+😐 neutral face indifference meh :| neutral
+😑 expressionless face face indifferent - - meh deadpan
+😶 face without mouth face hellokitty
+😏 smirking face face smile mean prank smug sarcasm
+😒 unamused face indifference bored straight face serious sarcasm unimpressed skeptical dubious side eye
+🙄 face with rolling eyes face eyeroll frustrated
+😬 grimacing face face grimace teeth
+🤥 lying face face lie pinocchio
+😌 relieved face face relaxed phew massage happiness
+😔 pensive face face sad depressed upset
+😪 sleepy face face tired rest nap
+🤤 drooling face face
+😴 sleeping face face tired sleepy night zzz
+😷 face with medical mask face sick ill disease
+🤒 face with thermometer sick temperature thermometer cold fever
+🤕 face with head bandage injured clumsy bandage hurt
+🤢 nauseated face face vomit gross green sick throw up ill
+🤮 face vomiting face sick
+🤧 sneezing face face gesundheit sneeze sick allergy
+🥵 hot face face feverish heat red sweating
+🥶 cold face face blue freezing frozen frostbite icicles
+🥴 woozy face face dizzy intoxicated tipsy wavy
+😵 dizzy face spent unconscious xox dizzy
+🤯 exploding head face shocked mind blown
+🤠 cowboy hat face face cowgirl hat
+🥳 partying face face celebration woohoo
+😎 smiling face with sunglasses face cool smile summer beach sunglass
+🤓 nerd face face nerdy geek dork
+🧐 face with monocle face stuffy wealthy
+😕 confused face face indifference huh weird hmmm :/
+😟 worried face face concern nervous :(
+🙁 slightly frowning face face frowning disappointed sad upset
+☹️ frowning face face sad upset frown
+😮 face with open mouth face surprise impressed wow whoa :O
+😯 hushed face face woo shh
+😲 astonished face face xox surprised poisoned
+😳 flushed face face blush shy flattered
+🥺 pleading face face begging mercy
+😦 frowning face with open mouth face aw what
+😧 anguished face face stunned nervous
+😨 fearful face face scared terrified nervous oops huh
+😰 anxious face with sweat face nervous sweat
+😥 sad but relieved face face phew sweat nervous
+😢 crying face face tears sad depressed upset :'(
+😭 loudly crying face face cry tears sad upset depressed
+😱 face screaming in fear face munch scared omg
+😖 confounded face face confused sick unwell oops :S
+😣 persevering face face sick no upset oops
+😞 disappointed face face sad upset depressed :(
+😓 downcast face with sweat face hot sad tired exercise
+😩 weary face face tired sleepy sad frustrated upset
+😫 tired face sick whine upset frustrated
+🥱 yawning face tired sleepy
+😤 face with steam from nose face gas phew proud pride
+😡 pouting face angry mad hate despise
+😠 angry face mad face annoyed frustrated
+🤬 face with symbols on mouth face swearing cursing cussing profanity expletive
+😈 smiling face with horns devil horns
+👿 angry face with horns devil angry horns
 💀 skull dead skeleton creepy death
-☠️ skull_and_crossbones poison danger deadly scary death pirate evil
-💩 pile_of_poo hankey shitface fail turd shit
-🤡 clown_face face
+☠️ skull and crossbones poison danger deadly scary death pirate evil
+💩 pile of poo hankey shitface fail turd shit
+🤡 clown face face
 👹 ogre monster red mask halloween scary creepy devil demon japanese ogre
 👺 goblin red evil mask monster scary creepy japanese goblin
 👻 ghost halloween spooky scary
-👽 alien UFO paul weird outer_space
-👾 alien_monster game arcade play
+👽 alien UFO paul weird outer space
+👾 alien monster game arcade play
 🤖 robot computer machine bot
-😺 grinning_cat animal cats happy smile
-😸 grinning_cat_with_smiling_eyes animal cats smile
-😹 cat_with_tears_of_joy animal cats haha happy tears
-😻 smiling_cat_with_heart_eyes animal love like affection cats valentines heart
-😼 cat_with_wry_smile animal cats smirk
-😽 kissing_cat animal cats kiss
-🙀 weary_cat animal cats munch scared scream
-😿 crying_cat animal tears weep sad cats upset cry
-😾 pouting_cat animal cats
-🙈 see_no_evil_monkey monkey animal nature haha
-🙉 hear_no_evil_monkey animal monkey nature
-🙊 speak_no_evil_monkey monkey animal nature omg
-💋 kiss_mark face lips love like affection valentines
-💌 love_letter email like affection envelope valentines
-💘 heart_with_arrow love like heart affection valentines
-💝 heart_with_ribbon love valentines
-💖 sparkling_heart love like affection valentines
-💗 growing_heart like love affection valentines pink
-💓 beating_heart love like affection valentines pink heart
-💞 revolving_hearts love like affection valentines
-💕 two_hearts love like affection valentines heart
-💟 heart_decoration purple-square love like
-❣️ heart_exclamation decoration love
-💔 broken_heart sad sorry break heart heartbreak
-❤️ red_heart love like valentines
-🧡 orange_heart love like affection valentines
-💛 yellow_heart love like affection valentines
-💚 green_heart love like affection valentines
-💙 blue_heart love like affection valentines
-💜 purple_heart love like affection valentines
-🤎 brown_heart coffee
-🖤 black_heart evil
-🤍 white_heart pure
-💯 hundred_points score perfect numbers century exam quiz test pass hundred
-💢 anger_symbol angry mad
+😺 grinning cat animal cats happy smile
+😸 grinning cat with smiling eyes animal cats smile
+😹 cat with tears of joy animal cats haha happy tears
+😻 smiling cat with heart eyes animal love like affection cats valentines heart
+😼 cat with wry smile animal cats smirk
+😽 kissing cat animal cats kiss
+🙀 weary cat animal cats munch scared scream
+😿 crying cat animal tears weep sad cats upset cry
+😾 pouting cat animal cats
+🙈 see no evil monkey monkey animal nature haha
+🙉 hear no evil monkey animal monkey nature
+🙊 speak no evil monkey monkey animal nature omg
+💋 kiss mark face lips love like affection valentines
+💌 love letter email like affection envelope valentines
+💘 heart with arrow love like heart affection valentines
+💝 heart with ribbon love valentines
+💖 sparkling heart love like affection valentines
+💗 growing heart like love affection valentines pink
+💓 beating heart love like affection valentines pink heart
+💞 revolving hearts love like affection valentines
+💕 two hearts love like affection valentines heart
+💟 heart decoration purple-square love like
+❣️ heart exclamation decoration love
+💔 broken heart sad sorry break heart heartbreak
+❤️ red heart love like valentines
+🧡 orange heart love like affection valentines
+💛 yellow heart love like affection valentines
+💚 green heart love like affection valentines
+💙 blue heart love like affection valentines
+💜 purple heart love like affection valentines
+🤎 brown heart coffee
+🖤 black heart evil
+🤍 white heart pure
+💯 hundred points score perfect numbers century exam quiz test pass hundred
+💢 anger symbol angry mad
 💥 collision bomb explode explosion collision blown
 💫 dizzy star sparkle shoot magic
-💦 sweat_droplets water drip oops
-💨 dashing_away wind air fast shoo fart smoke puff
+💦 sweat droplets water drip oops
+💨 dashing away wind air fast shoo fart smoke puff
 🕳️ hole embarrassing
 💣 bomb boom explode explosion terrorism
-💬 speech_balloon bubble words message talk chatting
-👁️‍🗨️ eye_in_speech_bubble info
-🗨️ left_speech_bubble words message talk chatting
-🗯️ right_anger_bubble caption speech thinking mad
-💭 thought_balloon bubble cloud speech thinking dream
+💬 speech balloon bubble words message talk chatting
+👁️‍🗨️ eye in speech bubble info
+🗨️ left speech bubble words message talk chatting
+🗯️ right anger bubble caption speech thinking mad
+💭 thought balloon bubble cloud speech thinking dream
 💤 zzz sleepy tired dream
-👋 waving_hand hands gesture goodbye solong farewell hello hi palm
-🤚 raised_back_of_hand fingers raised backhand
-🖐️ hand_with_fingers_splayed hand fingers palm
-✋ raised_hand fingers stop highfive palm ban
-🖖 vulcan_salute hand fingers spock star trek
-👌 ok_hand fingers limbs perfect ok okay
-🤏 pinching_hand tiny small size
-✌️ victory_hand fingers ohyeah hand peace victory two
-🤞 crossed_fingers good lucky
-🤟 love_you_gesture hand fingers gesture
-🤘 sign_of_the_horns hand fingers evil_eye sign_of_horns rock_on
-🤙 call_me_hand hands gesture shaka
-👈 backhand_index_pointing_left direction fingers hand left
-👉 backhand_index_pointing_right fingers hand direction right
-👆 backhand_index_pointing_up fingers hand direction up
-🖕 middle_finger hand fingers rude middle flipping
-👇 backhand_index_pointing_down fingers hand direction down
-☝️ index_pointing_up hand fingers direction up
-👍 thumbs_up thumbsup yes awesome good agree accept cool hand like +1
-👎 thumbs_down thumbsdown no dislike hand -1
-✊ raised_fist fingers hand grasp
-👊 oncoming_fist angry violence fist hit attack hand
-🤛 left_facing_fist hand fistbump
-🤜 right_facing_fist hand fistbump
-👏 clapping_hands hands praise applause congrats yay
-🙌 raising_hands gesture hooray yea celebration hands
-👐 open_hands fingers butterfly hands open
-🤲 palms_up_together hands gesture cupped prayer
+👋 waving hand hands gesture goodbye solong farewell hello hi palm
+🤚 raised back of hand fingers raised backhand
+🖐️ hand with fingers splayed hand fingers palm
+✋ raised hand fingers stop highfive palm ban
+🖖 vulcan salute hand fingers spock star trek
+👌 ok hand fingers limbs perfect ok okay
+🤏 pinching hand tiny small size
+✌️ victory hand fingers ohyeah hand peace victory two
+🤞 crossed fingers good lucky
+🤟 love you gesture hand fingers gesture
+🤘 sign of the horns hand fingers evil eye sign of horns rock on
+🤙 call me hand hands gesture shaka
+👈 backhand index pointing left direction fingers hand left
+👉 backhand index pointing right fingers hand direction right
+👆 backhand index pointing up fingers hand direction up
+🖕 middle finger hand fingers rude middle flipping
+👇 backhand index pointing down fingers hand direction down
+☝️ index pointing up hand fingers direction up
+👍 thumbs up thumbsup yes awesome good agree accept cool hand like +1
+👎 thumbs down thumbsdown no dislike hand -1
+✊ raised fist fingers hand grasp
+👊 oncoming fist angry violence fist hit attack hand
+🤛 left facing fist hand fistbump
+🤜 right facing fist hand fistbump
+👏 clapping hands hands praise applause congrats yay
+🙌 raising hands gesture hooray yea celebration hands
+👐 open hands fingers butterfly hands open
+🤲 palms up together hands gesture cupped prayer
 🤝 handshake agreement shake
-🙏 folded_hands please hope wish namaste highfive pray
-✍️ writing_hand lower_left_ballpoint_pen stationery write compose
-💅 nail_polish beauty manicure finger fashion nail
+🙏 folded hands please hope wish namaste highfive pray
+✍️ writing hand lower left ballpoint pen stationery write compose
+💅 nail polish beauty manicure finger fashion nail
 🤳 selfie camera phone
-💪 flexed_biceps arm flex hand summer strong biceps
-🦾 mechanical_arm accessibility
-🦿 mechanical_leg accessibility
+💪 flexed biceps arm flex hand summer strong biceps
+🦾 mechanical arm accessibility
+🦿 mechanical leg accessibility
 🦵 leg kick limb
 🦶 foot kick stomp
 👂 ear face hear sound listen
-🦻 ear_with_hearing_aid accessibility
+🦻 ear with hearing aid accessibility
 👃 nose smell sniff
 🧠 brain smart intelligent
 🦷 tooth teeth dentist
@@ -204,333 +204,333 @@ exit
 👦 boy man male guy teenager
 👧 girl female woman teenager
 🧑 person gender-neutral person
-👱 person_blond_hair hairstyle
+👱 person blond hair hairstyle
 👨 man mustache father dad guy classy sir moustache
-🧔 man_beard person bewhiskered
-👨‍🦰 man_red_hair hairstyle
-👨‍🦱 man_curly_hair hairstyle
-👨‍🦳 man_white_hair old elder
-👨‍🦲 man_bald hairless
+🧔 man beard person bewhiskered
+👨‍🦰 man red hair hairstyle
+👨‍🦱 man curly hair hairstyle
+👨‍🦳 man white hair old elder
+👨‍🦲 man bald hairless
 👩 woman female girls lady
-👩‍🦰 woman_red_hair hairstyle
-🧑‍🦰 person_red_hair hairstyle
-👩‍🦱 woman_curly_hair hairstyle
-🧑‍🦱 person_curly_hair hairstyle
-👩‍🦳 woman_white_hair old elder
-🧑‍🦳 person_white_hair elder old
-👩‍🦲 woman_bald hairless
-🧑‍🦲 person_bald hairless
-👱‍♀️ woman_blond_hair woman female girl blonde person
-👱‍♂️ man_blond_hair man male boy blonde guy person
-🧓 older_person human elder senior gender-neutral
-👴 old_man human male men old elder senior
-👵 old_woman human female women lady old elder senior
-🙍 person_frowning worried
-🙍‍♂️ man_frowning male boy man sad depressed discouraged unhappy
-🙍‍♀️ woman_frowning female girl woman sad depressed discouraged unhappy
-🙎 person_pouting upset
-🙎‍♂️ man_pouting male boy man
-🙎‍♀️ woman_pouting female girl woman
-🙅 person_gesturing_no decline
-🙅‍♂️ man_gesturing_no male boy man nope
-🙅‍♀️ woman_gesturing_no female girl woman nope
-🙆 person_gesturing_ok agree
-🙆‍♂️ man_gesturing_ok men boy male blue human man
-🙆‍♀️ woman_gesturing_ok women girl female pink human woman
-💁 person_tipping_hand information
-💁‍♂️ man_tipping_hand male boy man human information
-💁‍♀️ woman_tipping_hand female girl woman human information
-🙋 person_raising_hand question
-🙋‍♂️ man_raising_hand male boy man
-🙋‍♀️ woman_raising_hand female girl woman
-🧏 deaf_person accessibility
-🧏‍♂️ deaf_man accessibility
-🧏‍♀️ deaf_woman accessibility
-🙇 person_bowing respectiful
-🙇‍♂️ man_bowing man male boy
-🙇‍♀️ woman_bowing woman female girl
-🤦 person_facepalming disappointed
-🤦‍♂️ man_facepalming man male boy disbelief
-🤦‍♀️ woman_facepalming woman female girl disbelief
-🤷 person_shrugging regardless
-🤷‍♂️ man_shrugging man male boy confused indifferent doubt
-🤷‍♀️ woman_shrugging woman female girl confused indifferent doubt
-🧑‍⚕️ health_worker hospital
-👨‍⚕️ man_health_worker doctor nurse therapist healthcare man human
-👩‍⚕️ woman_health_worker doctor nurse therapist healthcare woman human
+👩‍🦰 woman red hair hairstyle
+🧑‍🦰 person red hair hairstyle
+👩‍🦱 woman curly hair hairstyle
+🧑‍🦱 person curly hair hairstyle
+👩‍🦳 woman white hair old elder
+🧑‍🦳 person white hair elder old
+👩‍🦲 woman bald hairless
+🧑‍🦲 person bald hairless
+👱‍♀️ woman blond hair woman female girl blonde person
+👱‍♂️ man blond hair man male boy blonde guy person
+🧓 older person human elder senior gender-neutral
+👴 old man human male men old elder senior
+👵 old woman human female women lady old elder senior
+🙍 person frowning worried
+🙍‍♂️ man frowning male boy man sad depressed discouraged unhappy
+🙍‍♀️ woman frowning female girl woman sad depressed discouraged unhappy
+🙎 person pouting upset
+🙎‍♂️ man pouting male boy man
+🙎‍♀️ woman pouting female girl woman
+🙅 person gesturing no decline
+🙅‍♂️ man gesturing no male boy man nope
+🙅‍♀️ woman gesturing no female girl woman nope
+🙆 person gesturing ok agree
+🙆‍♂️ man gesturing ok men boy male blue human man
+🙆‍♀️ woman gesturing ok women girl female pink human woman
+💁 person tipping hand information
+💁‍♂️ man tipping hand male boy man human information
+💁‍♀️ woman tipping hand female girl woman human information
+🙋 person raising hand question
+🙋‍♂️ man raising hand male boy man
+🙋‍♀️ woman raising hand female girl woman
+🧏 deaf person accessibility
+🧏‍♂️ deaf man accessibility
+🧏‍♀️ deaf woman accessibility
+🙇 person bowing respectiful
+🙇‍♂️ man bowing man male boy
+🙇‍♀️ woman bowing woman female girl
+🤦 person facepalming disappointed
+🤦‍♂️ man facepalming man male boy disbelief
+🤦‍♀️ woman facepalming woman female girl disbelief
+🤷 person shrugging regardless
+🤷‍♂️ man shrugging man male boy confused indifferent doubt
+🤷‍♀️ woman shrugging woman female girl confused indifferent doubt
+🧑‍⚕️ health worker hospital
+👨‍⚕️ man health worker doctor nurse therapist healthcare man human
+👩‍⚕️ woman health worker doctor nurse therapist healthcare woman human
 🧑‍🎓 student learn
-👨‍🎓 man_student graduate man human
-👩‍🎓 woman_student graduate woman human
+👨‍🎓 man student graduate man human
+👩‍🎓 woman student graduate woman human
 🧑‍🏫 teacher professor
-👨‍🏫 man_teacher instructor professor man human
-👩‍🏫 woman_teacher instructor professor woman human
+👨‍🏫 man teacher instructor professor man human
+👩‍🏫 woman teacher instructor professor woman human
 🧑‍⚖️ judge law
-👨‍⚖️ man_judge justice court man human
-👩‍⚖️ woman_judge justice court woman human
+👨‍⚖️ man judge justice court man human
+👩‍⚖️ woman judge justice court woman human
 🧑‍🌾 farmer crops
-👨‍🌾 man_farmer rancher gardener man human
-👩‍🌾 woman_farmer rancher gardener woman human
+👨‍🌾 man farmer rancher gardener man human
+👩‍🌾 woman farmer rancher gardener woman human
 🧑‍🍳 cook food kitchen culinary
-👨‍🍳 man_cook chef man human
-👩‍🍳 woman_cook chef woman human
+👨‍🍳 man cook chef man human
+👩‍🍳 woman cook chef woman human
 🧑‍🔧 mechanic worker technician
-👨‍🔧 man_mechanic plumber man human wrench
-👩‍🔧 woman_mechanic plumber woman human wrench
-🧑‍🏭 factory_worker labor
-👨‍🏭 man_factory_worker assembly industrial man human
-👩‍🏭 woman_factory_worker assembly industrial woman human
-🧑‍💼 office_worker business
-👨‍💼 man_office_worker business manager man human
-👩‍💼 woman_office_worker business manager woman human
+👨‍🔧 man mechanic plumber man human wrench
+👩‍🔧 woman mechanic plumber woman human wrench
+🧑‍🏭 factory worker labor
+👨‍🏭 man factory worker assembly industrial man human
+👩‍🏭 woman factory worker assembly industrial woman human
+🧑‍💼 office worker business
+👨‍💼 man office worker business manager man human
+👩‍💼 woman office worker business manager woman human
 🧑‍🔬 scientist chemistry
-👨‍🔬 man_scientist biologist chemist engineer physicist man human
-👩‍🔬 woman_scientist biologist chemist engineer physicist woman human
+👨‍🔬 man scientist biologist chemist engineer physicist man human
+👩‍🔬 woman scientist biologist chemist engineer physicist woman human
 🧑‍💻 technologist computer
-👨‍💻 man_technologist coder developer engineer programmer software man human laptop computer
-👩‍💻 woman_technologist coder developer engineer programmer software woman human laptop computer
+👨‍💻 man technologist coder developer engineer programmer software man human laptop computer
+👩‍💻 woman technologist coder developer engineer programmer software woman human laptop computer
 🧑‍🎤 singer song artist performer
-👨‍🎤 man_singer rockstar entertainer man human
-👩‍🎤 woman_singer rockstar entertainer woman human
+👨‍🎤 man singer rockstar entertainer man human
+👩‍🎤 woman singer rockstar entertainer woman human
 🧑‍🎨 artist painting draw creativity
-👨‍🎨 man_artist painter man human
-👩‍🎨 woman_artist painter woman human
+👨‍🎨 man artist painter man human
+👩‍🎨 woman artist painter woman human
 🧑‍✈️ pilot fly plane airplane
-👨‍✈️ man_pilot aviator plane man human
-👩‍✈️ woman_pilot aviator plane woman human
+👨‍✈️ man pilot aviator plane man human
+👩‍✈️ woman pilot aviator plane woman human
 🧑‍🚀 astronaut outerspace
-👨‍🚀 man_astronaut space rocket man human
-👩‍🚀 woman_astronaut space rocket woman human
+👨‍🚀 man astronaut space rocket man human
+👩‍🚀 woman astronaut space rocket woman human
 🧑‍🚒 firefighter fire
-👨‍🚒 man_firefighter fireman man human
-👩‍🚒 woman_firefighter fireman woman human
-👮 police_officer cop
-👮‍♂️ man_police_officer man police law legal enforcement arrest 911
-👮‍♀️ woman_police_officer woman police law legal enforcement arrest 911 female
+👨‍🚒 man firefighter fireman man human
+👩‍🚒 woman firefighter fireman woman human
+👮 police officer cop
+👮‍♂️ man police officer man police law legal enforcement arrest 911
+👮‍♀️ woman police officer woman police law legal enforcement arrest 911 female
 🕵️ detective human spy detective
-🕵️‍♂️ man_detective crime
-🕵️‍♀️ woman_detective human spy detective female woman
+🕵️‍♂️ man detective crime
+🕵️‍♀️ woman detective human spy detective female woman
 💂 guard protect
-💂‍♂️ man_guard uk gb british male guy royal
-💂‍♀️ woman_guard uk gb british female royal woman
-👷 construction_worker labor build
-👷‍♂️ man_construction_worker male human wip guy build construction worker labor
-👷‍♀️ woman_construction_worker female human wip build construction worker labor woman
+💂‍♂️ man guard uk gb british male guy royal
+💂‍♀️ woman guard uk gb british female royal woman
+👷 construction worker labor build
+👷‍♂️ man construction worker male human wip guy build construction worker labor
+👷‍♀️ woman construction worker female human wip build construction worker labor woman
 🤴 prince boy man male crown royal king
 👸 princess girl woman female blond crown royal queen
-👳 person_wearing_turban headdress
-👳‍♂️ man_wearing_turban male indian hinduism arabs
-👳‍♀️ woman_wearing_turban female indian hinduism arabs woman
-👲 man_with_skullcap male boy chinese
-🧕 woman_with_headscarf female hijab mantilla tichel
-🤵 man_in_tuxedo couple marriage wedding groom
-👰 bride_with_veil couple marriage wedding woman bride
-🤰 pregnant_woman baby
-🤱 breast_feeding nursing baby
-👼 baby_angel heaven wings halo
-🎅 santa_claus festival man male xmas father christmas
-🤶 mrs_claus woman female xmas mother christmas
+👳 person wearing turban headdress
+👳‍♂️ man wearing turban male indian hinduism arabs
+👳‍♀️ woman wearing turban female indian hinduism arabs woman
+👲 man with skullcap male boy chinese
+🧕 woman with headscarf female hijab mantilla tichel
+🤵 man in tuxedo couple marriage wedding groom
+👰 bride with veil couple marriage wedding woman bride
+🤰 pregnant woman baby
+🤱 breast feeding nursing baby
+👼 baby angel heaven wings halo
+🎅 santa claus festival man male xmas father christmas
+🤶 mrs claus woman female xmas mother christmas
 🦸 superhero marvel
-🦸‍♂️ man_superhero man male good hero superpowers
-🦸‍♀️ woman_superhero woman female good heroine superpowers
+🦸‍♂️ man superhero man male good hero superpowers
+🦸‍♀️ woman superhero woman female good heroine superpowers
 🦹 supervillain marvel
-🦹‍♂️ man_supervillain man male evil bad criminal hero superpowers
-🦹‍♀️ woman_supervillain woman female evil bad criminal heroine superpowers
+🦹‍♂️ man supervillain man male evil bad criminal hero superpowers
+🦹‍♀️ woman supervillain woman female evil bad criminal heroine superpowers
 🧙 mage magic
-🧙‍♂️ man_mage man male mage sorcerer
-🧙‍♀️ woman_mage woman female mage witch
+🧙‍♂️ man mage man male mage sorcerer
+🧙‍♀️ woman mage woman female mage witch
 🧚 fairy wings magical
-🧚‍♂️ man_fairy man male
-🧚‍♀️ woman_fairy woman female
+🧚‍♂️ man fairy man male
+🧚‍♀️ woman fairy woman female
 🧛 vampire blood twilight
-🧛‍♂️ man_vampire man male dracula
-🧛‍♀️ woman_vampire woman female
+🧛‍♂️ man vampire man male dracula
+🧛‍♀️ woman vampire woman female
 🧜 merperson sea
 🧜‍♂️ merman man male triton
 🧜‍♀️ mermaid woman female merwoman ariel
 🧝 elf magical
-🧝‍♂️ man_elf man male
-🧝‍♀️ woman_elf woman female
+🧝‍♂️ man elf man male
+🧝‍♀️ woman elf woman female
 🧞 genie magical wishes
-🧞‍♂️ man_genie man male
-🧞‍♀️ woman_genie woman female
+🧞‍♂️ man genie man male
+🧞‍♀️ woman genie woman female
 🧟 zombie dead
-🧟‍♂️ man_zombie man male dracula undead walking dead
-🧟‍♀️ woman_zombie woman female undead walking dead
-💆 person_getting_massage relax
-💆‍♂️ man_getting_massage male boy man head
-💆‍♀️ woman_getting_massage female girl woman head
-💇 person_getting_haircut hairstyle
-💇‍♂️ man_getting_haircut male boy man
-💇‍♀️ woman_getting_haircut female girl woman
-🚶 person_walking move
-🚶‍♂️ man_walking human feet steps
-🚶‍♀️ woman_walking human feet steps woman female
-🧍 person_standing still
-🧍‍♂️ man_standing still
-🧍‍♀️ woman_standing still
-🧎 person_kneeling pray respectful
-🧎‍♂️ man_kneeling pray respectful
-🧎‍♀️ woman_kneeling respectful pray
-🧑‍🦯 person_with_probing_cane blind
-👨‍🦯 man_with_probing_cane blind
-👩‍🦯 woman_with_probing_cane blind
-🧑‍🦼 person_in_motorized_wheelchair disability accessibility
-👨‍🦼 man_in_motorized_wheelchair disability accessibility
-👩‍🦼 woman_in_motorized_wheelchair disability accessibility
-🧑‍🦽 person_in_manual_wheelchair disability accessibility
-👨‍🦽 man_in_manual_wheelchair disability accessibility
-👩‍🦽 woman_in_manual_wheelchair disability accessibility
-🏃 person_running move
-🏃‍♂️ man_running man walking exercise race running
-🏃‍♀️ woman_running woman walking exercise race running female
-💃 woman_dancing female girl woman fun
-🕺 man_dancing male boy fun dancer
-🕴️ man_in_suit_levitating suit business levitate hover jump
-👯 people_with_bunny_ears perform costume
-👯‍♂️ men_with_bunny_ears male bunny men boys
-👯‍♀️ women_with_bunny_ears female bunny women girls
-🧖 person_in_steamy_room relax spa
-🧖‍♂️ man_in_steamy_room male man spa steamroom sauna
-🧖‍♀️ woman_in_steamy_room female woman spa steamroom sauna
-🧗 person_climbing sport
-🧗‍♂️ man_climbing sports hobby man male rock
-🧗‍♀️ woman_climbing sports hobby woman female rock
-🤺 person_fencing sports fencing sword
-🏇 horse_racing animal betting competition gambling luck
+🧟‍♂️ man zombie man male dracula undead walking dead
+🧟‍♀️ woman zombie woman female undead walking dead
+💆 person getting massage relax
+💆‍♂️ man getting massage male boy man head
+💆‍♀️ woman getting massage female girl woman head
+💇 person getting haircut hairstyle
+💇‍♂️ man getting haircut male boy man
+💇‍♀️ woman getting haircut female girl woman
+🚶 person walking move
+🚶‍♂️ man walking human feet steps
+🚶‍♀️ woman walking human feet steps woman female
+🧍 person standing still
+🧍‍♂️ man standing still
+🧍‍♀️ woman standing still
+🧎 person kneeling pray respectful
+🧎‍♂️ man kneeling pray respectful
+🧎‍♀️ woman kneeling respectful pray
+🧑‍🦯 person with probing cane blind
+👨‍🦯 man with probing cane blind
+👩‍🦯 woman with probing cane blind
+🧑‍🦼 person in motorized wheelchair disability accessibility
+👨‍🦼 man in motorized wheelchair disability accessibility
+👩‍🦼 woman in motorized wheelchair disability accessibility
+🧑‍🦽 person in manual wheelchair disability accessibility
+👨‍🦽 man in manual wheelchair disability accessibility
+👩‍🦽 woman in manual wheelchair disability accessibility
+🏃 person running move
+🏃‍♂️ man running man walking exercise race running
+🏃‍♀️ woman running woman walking exercise race running female
+💃 woman dancing female girl woman fun
+🕺 man dancing male boy fun dancer
+🕴️ man in suit levitating suit business levitate hover jump
+👯 people with bunny ears perform costume
+👯‍♂️ men with bunny ears male bunny men boys
+👯‍♀️ women with bunny ears female bunny women girls
+🧖 person in steamy room relax spa
+🧖‍♂️ man in steamy room male man spa steamroom sauna
+🧖‍♀️ woman in steamy room female woman spa steamroom sauna
+🧗 person climbing sport
+🧗‍♂️ man climbing sports hobby man male rock
+🧗‍♀️ woman climbing sports hobby woman female rock
+🤺 person fencing sports fencing sword
+🏇 horse racing animal betting competition gambling luck
 ⛷️ skier sports winter snow
 🏂 snowboarder sports winter
-🏌️ person_golfing sports business
-🏌️‍♂️ man_golfing sport
-🏌️‍♀️ woman_golfing sports business woman female
-🏄 person_surfing sport sea
-🏄‍♂️ man_surfing sports ocean sea summer beach
-🏄‍♀️ woman_surfing sports ocean sea summer beach woman female
-🚣 person_rowing_boat sport move
-🚣‍♂️ man_rowing_boat sports hobby water ship
-🚣‍♀️ woman_rowing_boat sports hobby water ship woman female
-🏊 person_swimming sport pool
-🏊‍♂️ man_swimming sports exercise human athlete water summer
-🏊‍♀️ woman_swimming sports exercise human athlete water summer woman female
-⛹️ person_bouncing_ball sports human
-⛹️‍♂️ man_bouncing_ball sport
-⛹️‍♀️ woman_bouncing_ball sports human woman female
-🏋️ person_lifting_weights sports training exercise
-🏋️‍♂️ man_lifting_weights sport
-🏋️‍♀️ woman_lifting_weights sports training exercise woman female
-🚴 person_biking sport move
-🚴‍♂️ man_biking sports bike exercise hipster
-🚴‍♀️ woman_biking sports bike exercise hipster woman female
-🚵 person_mountain_biking sport move
-🚵‍♂️ man_mountain_biking transportation sports human race bike
-🚵‍♀️ woman_mountain_biking transportation sports human race bike woman female
-🤸 person_cartwheeling sport gymnastic
-🤸‍♂️ man_cartwheeling gymnastics
-🤸‍♀️ woman_cartwheeling gymnastics
-🤼 people_wrestling sport
-🤼‍♂️ men_wrestling sports wrestlers
-🤼‍♀️ women_wrestling sports wrestlers
-🤽 person_playing_water_polo sport
-🤽‍♂️ man_playing_water_polo sports pool
-🤽‍♀️ woman_playing_water_polo sports pool
-🤾 person_playing_handball sport
-🤾‍♂️ man_playing_handball sports
-🤾‍♀️ woman_playing_handball sports
-🤹 person_juggling performance balance
-🤹‍♂️ man_juggling juggle balance skill multitask
-🤹‍♀️ woman_juggling juggle balance skill multitask
-🧘 person_in_lotus_position meditate
-🧘‍♂️ man_in_lotus_position man male meditation yoga serenity zen mindfulness
-🧘‍♀️ woman_in_lotus_position woman female meditation yoga serenity zen mindfulness
-🛀 person_taking_bath clean shower bathroom
-🛌 person_in_bed bed rest
-🧑‍🤝‍🧑 people_holding_hands friendship
-👭 women_holding_hands pair friendship couple love like female people human
-👫 woman_and_man_holding_hands pair people human love date dating like affection valentines marriage
-👬 men_holding_hands pair couple love like bromance friendship people human
+🏌️ person golfing sports business
+🏌️‍♂️ man golfing sport
+🏌️‍♀️ woman golfing sports business woman female
+🏄 person surfing sport sea
+🏄‍♂️ man surfing sports ocean sea summer beach
+🏄‍♀️ woman surfing sports ocean sea summer beach woman female
+🚣 person rowing boat sport move
+🚣‍♂️ man rowing boat sports hobby water ship
+🚣‍♀️ woman rowing boat sports hobby water ship woman female
+🏊 person swimming sport pool
+🏊‍♂️ man swimming sports exercise human athlete water summer
+🏊‍♀️ woman swimming sports exercise human athlete water summer woman female
+⛹️ person bouncing ball sports human
+⛹️‍♂️ man bouncing ball sport
+⛹️‍♀️ woman bouncing ball sports human woman female
+🏋️ person lifting weights sports training exercise
+🏋️‍♂️ man lifting weights sport
+🏋️‍♀️ woman lifting weights sports training exercise woman female
+🚴 person biking sport move
+🚴‍♂️ man biking sports bike exercise hipster
+🚴‍♀️ woman biking sports bike exercise hipster woman female
+🚵 person mountain biking sport move
+🚵‍♂️ man mountain biking transportation sports human race bike
+🚵‍♀️ woman mountain biking transportation sports human race bike woman female
+🤸 person cartwheeling sport gymnastic
+🤸‍♂️ man cartwheeling gymnastics
+🤸‍♀️ woman cartwheeling gymnastics
+🤼 people wrestling sport
+🤼‍♂️ men wrestling sports wrestlers
+🤼‍♀️ women wrestling sports wrestlers
+🤽 person playing water polo sport
+🤽‍♂️ man playing water polo sports pool
+🤽‍♀️ woman playing water polo sports pool
+🤾 person playing handball sport
+🤾‍♂️ man playing handball sports
+🤾‍♀️ woman playing handball sports
+🤹 person juggling performance balance
+🤹‍♂️ man juggling juggle balance skill multitask
+🤹‍♀️ woman juggling juggle balance skill multitask
+🧘 person in lotus position meditate
+🧘‍♂️ man in lotus position man male meditation yoga serenity zen mindfulness
+🧘‍♀️ woman in lotus position woman female meditation yoga serenity zen mindfulness
+🛀 person taking bath clean shower bathroom
+🛌 person in bed bed rest
+🧑‍🤝‍🧑 people holding hands friendship
+👭 women holding hands pair friendship couple love like female people human
+👫 woman and man holding hands pair people human love date dating like affection valentines marriage
+👬 men holding hands pair couple love like bromance friendship people human
 💏 kiss pair valentines love like dating marriage
-👩‍❤️‍💋‍👨 kiss_woman_man love
-👨‍❤️‍💋‍👨 kiss_man_man pair valentines love like dating marriage
-👩‍❤️‍💋‍👩 kiss_woman_woman pair valentines love like dating marriage
-💑 couple_with_heart pair love like affection human dating valentines marriage
-👩‍❤️‍👨 couple_with_heart_woman_man love
-👨‍❤️‍👨 couple_with_heart_man_man pair love like affection human dating valentines marriage
-👩‍❤️‍👩 couple_with_heart_woman_woman pair love like affection human dating valentines marriage
+👩‍❤️‍💋‍👨 kiss woman man love
+👨‍❤️‍💋‍👨 kiss man man pair valentines love like dating marriage
+👩‍❤️‍💋‍👩 kiss woman woman pair valentines love like dating marriage
+💑 couple with heart pair love like affection human dating valentines marriage
+👩‍❤️‍👨 couple with heart woman man love
+👨‍❤️‍👨 couple with heart man man pair love like affection human dating valentines marriage
+👩‍❤️‍👩 couple with heart woman woman pair love like affection human dating valentines marriage
 👪 family home parents child mom dad father mother people human
-👨‍👩‍👦 family_man_woman_boy love
-👨‍👩‍👧 family_man_woman_girl home parents people human child
-👨‍👩‍👧‍👦 family_man_woman_girl_boy home parents people human children
-👨‍👩‍👦‍👦 family_man_woman_boy_boy home parents people human children
-👨‍👩‍👧‍👧 family_man_woman_girl_girl home parents people human children
-👨‍👨‍👦 family_man_man_boy home parents people human children
-👨‍👨‍👧 family_man_man_girl home parents people human children
-👨‍👨‍👧‍👦 family_man_man_girl_boy home parents people human children
-👨‍👨‍👦‍👦 family_man_man_boy_boy home parents people human children
-👨‍👨‍👧‍👧 family_man_man_girl_girl home parents people human children
-👩‍👩‍👦 family_woman_woman_boy home parents people human children
-👩‍👩‍👧 family_woman_woman_girl home parents people human children
-👩‍👩‍👧‍👦 family_woman_woman_girl_boy home parents people human children
-👩‍👩‍👦‍👦 family_woman_woman_boy_boy home parents people human children
-👩‍👩‍👧‍👧 family_woman_woman_girl_girl home parents people human children
-👨‍👦 family_man_boy home parent people human child
-👨‍👦‍👦 family_man_boy_boy home parent people human children
-👨‍👧 family_man_girl home parent people human child
-👨‍👧‍👦 family_man_girl_boy home parent people human children
-👨‍👧‍👧 family_man_girl_girl home parent people human children
-👩‍👦 family_woman_boy home parent people human child
-👩‍👦‍👦 family_woman_boy_boy home parent people human children
-👩‍👧 family_woman_girl home parent people human child
-👩‍👧‍👦 family_woman_girl_boy home parent people human children
-👩‍👧‍👧 family_woman_girl_girl home parent people human children
-🗣️ speaking_head user person human sing say talk
-👤 bust_in_silhouette user person human
-👥 busts_in_silhouette user person human group team
+👨‍👩‍👦 family man woman boy love
+👨‍👩‍👧 family man woman girl home parents people human child
+👨‍👩‍👧‍👦 family man woman girl boy home parents people human children
+👨‍👩‍👦‍👦 family man woman boy boy home parents people human children
+👨‍👩‍👧‍👧 family man woman girl girl home parents people human children
+👨‍👨‍👦 family man man boy home parents people human children
+👨‍👨‍👧 family man man girl home parents people human children
+👨‍👨‍👧‍👦 family man man girl boy home parents people human children
+👨‍👨‍👦‍👦 family man man boy boy home parents people human children
+👨‍👨‍👧‍👧 family man man girl girl home parents people human children
+👩‍👩‍👦 family woman woman boy home parents people human children
+👩‍👩‍👧 family woman woman girl home parents people human children
+👩‍👩‍👧‍👦 family woman woman girl boy home parents people human children
+👩‍👩‍👦‍👦 family woman woman boy boy home parents people human children
+👩‍👩‍👧‍👧 family woman woman girl girl home parents people human children
+👨‍👦 family man boy home parent people human child
+👨‍👦‍👦 family man boy boy home parent people human children
+👨‍👧 family man girl home parent people human child
+👨‍👧‍👦 family man girl boy home parent people human children
+👨‍👧‍👧 family man girl girl home parent people human children
+👩‍👦 family woman boy home parent people human child
+👩‍👦‍👦 family woman boy boy home parent people human children
+👩‍👧 family woman girl home parent people human child
+👩‍👧‍👦 family woman girl boy home parent people human children
+👩‍👧‍👧 family woman girl girl home parent people human children
+🗣️ speaking head user person human sing say talk
+👤 bust in silhouette user person human
+👥 busts in silhouette user person human group team
 👣 footprints feet tracking walking beach
-🐵 monkey_face animal nature circus
+🐵 monkey face animal nature circus
 🐒 monkey animal nature banana circus
 🦍 gorilla animal nature circus
 🦧 orangutan animal
-🐶 dog_face animal friend nature woof puppy pet faithful
+🐶 dog face animal friend nature woof puppy pet faithful
 🐕 dog animal nature friend doge pet faithful
-🦮 guide_dog animal blind
-🐕‍🦺 service_dog blind animal
+🦮 guide dog animal blind
+🐕‍🦺 service dog blind animal
 🐩 poodle dog animal 101 nature pet
 🐺 wolf animal nature wild
 🦊 fox animal nature face
 🦝 raccoon animal nature
-🐱 cat_face animal meow nature pet kitten
+🐱 cat face animal meow nature pet kitten
 🐈 cat animal meow pet cats
 🦁 lion animal nature
-🐯 tiger_face animal cat danger wild nature roar
+🐯 tiger face animal cat danger wild nature roar
 🐅 tiger animal nature roar
 🐆 leopard animal nature
-🐴 horse_face animal brown nature
+🐴 horse face animal brown nature
 🐎 horse animal gamble luck
 🦄 unicorn animal nature mystical
 🦓 zebra animal nature stripes safari
 🦌 deer animal nature horns venison
-🐮 cow_face beef ox animal nature moo milk
+🐮 cow face beef ox animal nature moo milk
 🐂 ox animal cow beef
-🐃 water_buffalo animal nature ox cow
+🐃 water buffalo animal nature ox cow
 🐄 cow beef ox animal nature moo milk
-🐷 pig_face animal oink nature
+🐷 pig face animal oink nature
 🐖 pig animal nature
 🐗 boar animal nature
-🐽 pig_nose animal oink
+🐽 pig nose animal oink
 🐏 ram animal sheep nature
 🐑 ewe animal nature wool shipit
 🐐 goat animal nature
 🐪 camel animal hot desert hump
-🐫 two_hump_camel animal nature hot desert hump
+🐫 two hump camel animal nature hot desert hump
 🦙 llama animal nature alpaca
 🦒 giraffe animal nature spots safari
 🐘 elephant animal nature nose th circus
 🦏 rhinoceros animal nature horn
 🦛 hippopotamus animal nature
-🐭 mouse_face animal nature cheese_wedge rodent
+🐭 mouse face animal nature cheese wedge rodent
 🐁 mouse animal nature rodent
 🐀 rat animal mouse rodent
 🐹 hamster animal nature
-🐰 rabbit_face animal nature pet spring magic bunny
+🐰 rabbit face animal nature pet spring magic bunny
 🐇 rabbit animal nature pet magic spring
 🐿️ chipmunk animal nature rodent squirrel
 🦔 hedgehog animal nature spiny
@@ -543,13 +543,13 @@ exit
 🦨 skunk animal
 🦘 kangaroo animal nature australia joey hop marsupial
 🦡 badger animal nature honey
-🐾 paw_prints animal tracking footprints dog cat pet feet
+🐾 paw prints animal tracking footprints dog cat pet feet
 🦃 turkey animal bird
 🐔 chicken animal cluck nature bird
 🐓 rooster animal nature chicken
-🐣 hatching_chick animal chicken egg born baby bird
-🐤 baby_chick animal chicken bird
-🐥 front_facing_baby_chick animal chicken baby bird
+🐣 hatching chick animal chicken egg born baby bird
+🐤 baby chick animal chicken bird
+🐥 front facing baby chick animal chicken baby bird
 🐦 bird animal nature fly tweet spring
 🐧 penguin animal nature
 🕊️ dove animal bird
@@ -565,53 +565,53 @@ exit
 🐢 turtle animal slow nature tortoise
 🦎 lizard animal nature reptile
 🐍 snake animal evil nature hiss python
-🐲 dragon_face animal myth nature chinese green
+🐲 dragon face animal myth nature chinese green
 🐉 dragon animal myth nature chinese green
 🦕 sauropod animal nature dinosaur brachiosaurus brontosaurus diplodocus extinct
-🦖 t_rex animal nature dinosaur tyrannosaurus extinct
-🐳 spouting_whale animal nature sea ocean
+🦖 t rex animal nature dinosaur tyrannosaurus extinct
+🐳 spouting whale animal nature sea ocean
 🐋 whale animal nature sea ocean
 🐬 dolphin animal nature fish sea ocean flipper fins beach
 🐟 fish animal food nature
-🐠 tropical_fish animal swim ocean beach nemo
+🐠 tropical fish animal swim ocean beach nemo
 🐡 blowfish animal nature food sea ocean
 🦈 shark animal nature fish sea ocean jaws fins beach
 🐙 octopus animal creature ocean sea nature beach
-🐚 spiral_shell nature sea beach
+🐚 spiral shell nature sea beach
 🐌 snail slow animal shell
 🦋 butterfly animal insect nature caterpillar
 🐛 bug animal insect nature worm
 🐜 ant animal insect nature bug
 🐝 honeybee animal insect nature bug spring honey
-🐞 lady_beetle animal insect nature ladybug
+🐞 lady beetle animal insect nature ladybug
 🦗 cricket animal cricket chirp
 🕷️ spider animal arachnid
-🕸️ spider_web animal insect arachnid silk
+🕸️ spider web animal insect arachnid silk
 🦂 scorpion animal arachnid
 🦟 mosquito animal nature insect malaria
 🦠 microbe amoeba bacteria germs virus
 💐 bouquet flowers nature spring
-🌸 cherry_blossom nature plant spring flower
-💮 white_flower japanese spring
+🌸 cherry blossom nature plant spring flower
+💮 white flower japanese spring
 🏵️ rosette flower decoration military
 🌹 rose flowers valentines love spring
-🥀 wilted_flower plant nature flower
+🥀 wilted flower plant nature flower
 🌺 hibiscus plant vegetable flowers beach
 🌻 sunflower nature plant fall
 🌼 blossom nature flowers yellow
 🌷 tulip flowers plant nature summer spring
 🌱 seedling plant nature grass lawn spring
-🌲 evergreen_tree plant nature
-🌳 deciduous_tree plant nature
-🌴 palm_tree plant vegetable nature summer beach mojito tropical
+🌲 evergreen tree plant nature
+🌳 deciduous tree plant nature
+🌴 palm tree plant vegetable nature summer beach mojito tropical
 🌵 cactus vegetable plant nature
-🌾 sheaf_of_rice nature plant
+🌾 sheaf of rice nature plant
 🌿 herb vegetable plant medicine weed grass lawn
 ☘️ shamrock vegetable plant nature irish clover
-🍀 four_leaf_clover vegetable plant nature lucky irish
-🍁 maple_leaf nature plant vegetable ca fall
-🍂 fallen_leaf nature plant vegetable leaves
-🍃 leaf_fluttering_in_wind nature plant tree vegetable grass lawn spring
+🍀 four leaf clover vegetable plant nature lucky irish
+🍁 maple leaf nature plant vegetable ca fall
+🍂 fallen leaf nature plant vegetable leaves
+🍃 leaf fluttering in wind nature plant tree vegetable grass lawn spring
 🍇 grapes fruit food wine
 🍈 melon fruit nature food
 🍉 watermelon fruit food picnic summer
@@ -620,23 +620,23 @@ exit
 🍌 banana fruit food monkey
 🍍 pineapple fruit nature food
 🥭 mango fruit food tropical
-🍎 red_apple fruit mac school
-🍏 green_apple fruit nature
+🍎 red apple fruit mac school
+🍏 green apple fruit nature
 🍐 pear fruit nature food
 🍑 peach fruit nature food
 🍒 cherries food fruit
 🍓 strawberry fruit food nature
-🥝 kiwi_fruit fruit food
+🥝 kiwi fruit fruit food
 🍅 tomato fruit vegetable nature food
 🥥 coconut fruit nature food palm
 🥑 avocado fruit food
 🍆 eggplant vegetable nature food aubergine
 🥔 potato food tuber vegatable starch
 🥕 carrot vegetable food orange
-🌽 ear_of_corn food vegetable plant
-🌶️ hot_pepper food spicy chilli chili
+🌽 ear of corn food vegetable plant
+🌶️ hot pepper food spicy chilli chili
 🥒 cucumber fruit food pickle
-🥬 leafy_green food vegetable plant bok choy cabbage kale lettuce
+🥬 leafy green food vegetable plant bok choy cabbage kale lettuce
 🥦 broccoli fruit food vegetable
 🧄 garlic food spice cook
 🧅 onion cook food spice
@@ -645,390 +645,390 @@ exit
 🌰 chestnut food squirrel
 🍞 bread food wheat breakfast toast
 🥐 croissant food bread french
-🥖 baguette_bread food bread french
+🥖 baguette bread food bread french
 🥨 pretzel food bread twisted
 🥯 bagel food bread bakery schmear
 🥞 pancakes food breakfast flapjacks hotcakes
 🧇 waffle food breakfast
-🧀 cheese_wedge food chadder
-🍖 meat_on_bone good food drumstick
-🍗 poultry_leg food meat drumstick bird chicken turkey
-🥩 cut_of_meat food cow meat cut chop lambchop porkchop
+🧀 cheese wedge food chadder
+🍖 meat on bone good food drumstick
+🍗 poultry leg food meat drumstick bird chicken turkey
+🥩 cut of meat food cow meat cut chop lambchop porkchop
 🥓 bacon food breakfast pork pig meat
 🍔 hamburger meat fast food beef cheeseburger mcdonalds burger king
-🍟 french_fries chips snack fast food
+🍟 french fries chips snack fast food
 🍕 pizza food party
-🌭 hot_dog food frankfurter
+🌭 hot dog food frankfurter
 🥪 sandwich food lunch bread
 🌮 taco food mexican
 🌯 burrito food mexican
-🥙 stuffed_flatbread food flatbread stuffed gyro
+🥙 stuffed flatbread food flatbread stuffed gyro
 🧆 falafel food
 🥚 egg food chicken breakfast
 🍳 cooking food breakfast kitchen egg
-🥘 shallow_pan_of_food food cooking casserole paella
-🍲 pot_of_food food meat soup
-🥣 bowl_with_spoon food breakfast cereal oatmeal porridge
-🥗 green_salad food healthy lettuce
+🥘 shallow pan of food food cooking casserole paella
+🍲 pot of food food meat soup
+🥣 bowl with spoon food breakfast cereal oatmeal porridge
+🥗 green salad food healthy lettuce
 🍿 popcorn food movie theater films snack
 🧈 butter food cook
 🧂 salt condiment shaker
-🥫 canned_food food soup
-🍱 bento_box food japanese box
-🍘 rice_cracker food japanese
-🍙 rice_ball food japanese
-🍚 cooked_rice food china asian
-🍛 curry_rice food spicy hot indian
-🍜 steaming_bowl food japanese noodle chopsticks
+🥫 canned food food soup
+🍱 bento box food japanese box
+🍘 rice cracker food japanese
+🍙 rice ball food japanese
+🍚 cooked rice food china asian
+🍛 curry rice food spicy hot indian
+🍜 steaming bowl food japanese noodle chopsticks
 🍝 spaghetti food italian noodle
-🍠 roasted_sweet_potato food nature
+🍠 roasted sweet potato food nature
 🍢 oden food japanese
 🍣 sushi food fish japanese rice
-🍤 fried_shrimp food animal appetizer summer
-🍥 fish_cake_with_swirl food japan sea beach narutomaki pink swirl kamaboko surimi ramen
-🥮 moon_cake food autumn
+🍤 fried shrimp food animal appetizer summer
+🍥 fish cake with swirl food japan sea beach narutomaki pink swirl kamaboko surimi ramen
+🥮 moon cake food autumn
 🍡 dango food dessert sweet japanese barbecue meat
 🥟 dumpling food empanada pierogi potsticker
-🥠 fortune_cookie food prophecy
-🥡 takeout_box food leftovers
+🥠 fortune cookie food prophecy
+🥡 takeout box food leftovers
 🦀 crab animal crustacean
 🦞 lobster animal nature bisque claws seafood
 🦐 shrimp animal ocean nature seafood
 🦑 squid animal nature ocean sea
 🦪 oyster food
-🍦 soft_ice_cream food hot dessert summer
-🍧 shaved_ice hot dessert summer
-🍨 ice_cream food hot dessert
+🍦 soft ice cream food hot dessert summer
+🍧 shaved ice hot dessert summer
+🍨 ice cream food hot dessert
 🍩 doughnut food dessert snack sweet donut
 🍪 cookie food snack oreo chocolate sweet dessert
-🎂 birthday_cake food dessert cake
+🎂 birthday cake food dessert cake
 🍰 shortcake food dessert
 🧁 cupcake food dessert bakery sweet
 🥧 pie food dessert pastry
-🍫 chocolate_bar food snack dessert sweet
+🍫 chocolate bar food snack dessert sweet
 🍬 candy snack dessert sweet lolly
 🍭 lollipop food snack candy sweet
 🍮 custard dessert food
-🍯 honey_pot bees sweet kitchen
-🍼 baby_bottle food container milk
-🥛 glass_of_milk beverage drink cow
-☕ hot_beverage beverage caffeine latte espresso coffee
-🍵 teacup_without_handle drink bowl breakfast green british
+🍯 honey pot bees sweet kitchen
+🍼 baby bottle food container milk
+🥛 glass of milk beverage drink cow
+☕ hot beverage beverage caffeine latte espresso coffee
+🍵 teacup without handle drink bowl breakfast green british
 🍶 sake wine drink drunk beverage japanese alcohol booze
-🍾 bottle_with_popping_cork drink wine bottle celebration
-🍷 wine_glass drink beverage drunk alcohol booze
-🍸 cocktail_glass drink drunk alcohol beverage booze mojito
-🍹 tropical_drink beverage cocktail summer beach alcohol booze mojito
-🍺 beer_mug relax beverage drink drunk party pub summer alcohol booze
-🍻 clinking_beer_mugs relax beverage drink drunk party pub summer alcohol booze
-🥂 clinking_glasses beverage drink party alcohol celebrate cheers wine champagne toast
-🥃 tumbler_glass drink beverage drunk alcohol liquor booze bourbon scotch whisky glass shot
-🥤 cup_with_straw drink soda
-🧃 beverage_box drink
+🍾 bottle with popping cork drink wine bottle celebration
+🍷 wine glass drink beverage drunk alcohol booze
+🍸 cocktail glass drink drunk alcohol beverage booze mojito
+🍹 tropical drink beverage cocktail summer beach alcohol booze mojito
+🍺 beer mug relax beverage drink drunk party pub summer alcohol booze
+🍻 clinking beer mugs relax beverage drink drunk party pub summer alcohol booze
+🥂 clinking glasses beverage drink party alcohol celebrate cheers wine champagne toast
+🥃 tumbler glass drink beverage drunk alcohol liquor booze bourbon scotch whisky glass shot
+🥤 cup with straw drink soda
+🧃 beverage box drink
 🧉 mate drink tea beverage
 🧊 ice water cold
 🥢 chopsticks food
-🍽️ fork_and_knife_with_plate food eat meal lunch dinner restaurant
-🍴 fork_and_knife cutlery kitchen
+🍽️ fork and knife with plate food eat meal lunch dinner restaurant
+🍴 fork and knife cutlery kitchen
 🥄 spoon cutlery kitchen tableware
-🔪 kitchen_knife knife blade cutlery kitchen weapon
+🔪 kitchen knife knife blade cutlery kitchen weapon
 🏺 amphora vase jar
-🌍 globe_showing_europe_africa globe world international
-🌎 globe_showing_americas globe world USA international
-🌏 globe_showing_asia_australia globe world east international
-🌐 globe_with_meridians earth international world internet interweb i18n
-🗺️ world_map location direction
-🗾 map_of_japan nation country japanese asia
+🌍 globe showing europe africa globe world international
+🌎 globe showing americas globe world USA international
+🌏 globe showing asia australia globe world east international
+🌐 globe with meridians earth international world internet interweb i18n
+🗺️ world map location direction
+🗾 map of japan nation country japanese asia
 🧭 compass magnetic navigation orienteering
-🏔️ snow_capped_mountain photo nature environment winter cold
+🏔️ snow capped mountain photo nature environment winter cold
 ⛰️ mountain photo nature environment
 🌋 volcano photo nature disaster
-🗻 mount_fuji photo mountain nature japanese
+🗻 mount fuji photo mountain nature japanese
 🏕️ camping photo outdoors tent
-🏖️ beach_with_umbrella weather summer sunny sand mojito
+🏖️ beach with umbrella weather summer sunny sand mojito
 🏜️ desert photo warm saharah
-🏝️ desert_island photo tropical mojito
-🏞️ national_park photo environment nature
+🏝️ desert island photo tropical mojito
+🏞️ national park photo environment nature
 🏟️ stadium photo place sports concert venue
-🏛️ classical_building art culture history
-🏗️ building_construction wip working progress
+🏛️ classical building art culture history
+🏗️ building construction wip working progress
 🧱 brick bricks
 🏘️ houses buildings photo
-🏚️ derelict_house abandon evict broken building
+🏚️ derelict house abandon evict broken building
 🏠 house building home
-🏡 house_with_garden home plant nature
-🏢 office_building building bureau work
-🏣 japanese_post_office building envelope communication
-🏤 post_office building email
+🏡 house with garden home plant nature
+🏢 office building building bureau work
+🏣 japanese post office building envelope communication
+🏤 post office building email
 🏥 hospital building health surgery doctor
 🏦 bank building money sales cash business enterprise
 🏨 hotel building accomodation checkin
-🏩 love_hotel like affection dating
-🏪 convenience_store building shopping groceries
+🏩 love hotel like affection dating
+🏪 convenience store building shopping groceries
 🏫 school building student education learn teach
-🏬 department_store building shopping mall
+🏬 department store building shopping mall
 🏭 factory building industry pollution smoke
-🏯 japanese_castle photo building
+🏯 japanese castle photo building
 🏰 castle building royalty history
 💒 wedding love like affection couple marriage bride groom
-🗼 tokyo_tower photo japanese
-🗽 statue_of_liberty american newyork
+🗼 tokyo tower photo japanese
+🗽 statue of liberty american newyork
 ⛪ church building religion christ
 🕌 mosque islam worship minaret
-🛕 hindu_temple religion
+🛕 hindu temple religion
 🕍 synagogue judaism worship temple jewish
-⛩️ shinto_shrine temple japan kyoto
+⛩️ shinto shrine temple japan kyoto
 🕋 kaaba mecca mosque islam
 ⛲ fountain photo summer water fresh
 ⛺ tent photo camping outdoors
 🌁 foggy photo mountain
-🌃 night_with_stars evening city downtown
+🌃 night with stars evening city downtown
 🏙️ cityscape photo night life urban
-🌄 sunrise_over_mountains view vacation photo
+🌄 sunrise over mountains view vacation photo
 🌅 sunrise morning view vacation photo
-🌆 cityscape_at_dusk photo evening sky buildings
+🌆 cityscape at dusk photo evening sky buildings
 🌇 sunset photo good morning dawn
-🌉 bridge_at_night photo sanfrancisco
-♨️ hot_springs bath warm relax
-🎠 carousel_horse photo carnival
-🎡 ferris_wheel photo carnival londoneye
-🎢 roller_coaster carnival playground photo fun
-💈 barber_pole hair salon style
-🎪 circus_tent festival carnival party
+🌉 bridge at night photo sanfrancisco
+♨️ hot springs bath warm relax
+🎠 carousel horse photo carnival
+🎡 ferris wheel photo carnival londoneye
+🎢 roller coaster carnival playground photo fun
+💈 barber pole hair salon style
+🎪 circus tent festival carnival party
 🚂 locomotive transportation vehicle train
-🚃 railway_car transportation vehicle
-🚄 high_speed_train transportation vehicle
-🚅 bullet_train transportation vehicle speed fast public travel
+🚃 railway car transportation vehicle
+🚄 high speed train transportation vehicle
+🚅 bullet train transportation vehicle speed fast public travel
 🚆 train transportation vehicle
 🚇 metro transportation blue-square mrt underground tube
-🚈 light_rail transportation vehicle
+🚈 light rail transportation vehicle
 🚉 station transportation vehicle public
 🚊 tram transportation vehicle
 🚝 monorail transportation vehicle
-🚞 mountain_railway transportation vehicle
-🚋 tram_car transportation vehicle carriage public travel
+🚞 mountain railway transportation vehicle
+🚋 tram car transportation vehicle carriage public travel
 🚌 bus car vehicle transportation
-🚍 oncoming_bus vehicle transportation
+🚍 oncoming bus vehicle transportation
 🚎 trolleybus bart transportation vehicle
 🚐 minibus vehicle car transportation
 🚑 ambulance health 911 hospital
-🚒 fire_engine transportation cars vehicle
-🚓 police_car vehicle cars transportation law legal enforcement
-🚔 oncoming_police_car vehicle law legal enforcement 911
+🚒 fire engine transportation cars vehicle
+🚓 police car vehicle cars transportation law legal enforcement
+🚔 oncoming police car vehicle law legal enforcement 911
 🚕 taxi uber vehicle cars transportation
-🚖 oncoming_taxi vehicle cars uber
+🚖 oncoming taxi vehicle cars uber
 🚗 automobile red transportation vehicle
-🚘 oncoming_automobile car vehicle transportation
-🚙 sport_utility_vehicle transportation vehicle
-🚚 delivery_truck cars transportation
-🚛 articulated_lorry vehicle cars transportation express
+🚘 oncoming automobile car vehicle transportation
+🚙 sport utility vehicle transportation vehicle
+🚚 delivery truck cars transportation
+🚛 articulated lorry vehicle cars transportation express
 🚜 tractor vehicle car farming agriculture
-🏎️ racing_car sports race fast formula f1
+🏎️ racing car sports race fast formula f1
 🏍️ motorcycle race sports fast
-🛵 motor_scooter vehicle vespa sasha
-🦽 manual_wheelchair accessibility
-🦼 motorized_wheelchair accessibility
-🛺 auto_rickshaw move transportation
+🛵 motor scooter vehicle vespa sasha
+🦽 manual wheelchair accessibility
+🦼 motorized wheelchair accessibility
+🛺 auto rickshaw move transportation
 🚲 bicycle sports bicycle exercise hipster
-🛴 kick_scooter vehicle kick razor
+🛴 kick scooter vehicle kick razor
 🛹 skateboard board
-🚏 bus_stop transportation wait
+🚏 bus stop transportation wait
 🛣️ motorway road cupertino interstate highway
-🛤️ railway_track train transportation
-🛢️ oil_drum barrell
-⛽ fuel_pump gas station petroleum
-🚨 police_car_light police ambulance 911 emergency alert error pinged law legal
-🚥 horizontal_traffic_light transportation signal
-🚦 vertical_traffic_light transportation driving
-🛑 stop_sign stop
+🛤️ railway track train transportation
+🛢️ oil drum barrell
+⛽ fuel pump gas station petroleum
+🚨 police car light police ambulance 911 emergency alert error pinged law legal
+🚥 horizontal traffic light transportation signal
+🚦 vertical traffic light transportation driving
+🛑 stop sign stop
 🚧 construction wip progress caution warning
 ⚓ anchor ship ferry sea boat
 ⛵ sailboat ship summer transportation water sailing
 🛶 canoe boat paddle water ship
 🚤 speedboat ship transportation vehicle summer
-🛳️ passenger_ship yacht cruise ferry
+🛳️ passenger ship yacht cruise ferry
 ⛴️ ferry boat ship yacht
-🛥️ motor_boat ship
+🛥️ motor boat ship
 🚢 ship transportation titanic deploy
 ✈️ airplane vehicle transportation flight fly
-🛩️ small_airplane flight transportation fly vehicle
-🛫 airplane_departure airport flight landing
-🛬 airplane_arrival airport flight boarding
+🛩️ small airplane flight transportation fly vehicle
+🛫 airplane departure airport flight landing
+🛬 airplane arrival airport flight boarding
 🪂 parachute fly glide
 💺 seat sit airplane transport bus flight fly
 🚁 helicopter transportation vehicle fly
-🚟 suspension_railway vehicle transportation
-🚠 mountain_cableway transportation vehicle ski
-🚡 aerial_tramway transportation vehicle ski
+🚟 suspension railway vehicle transportation
+🚠 mountain cableway transportation vehicle ski
+🚡 aerial tramway transportation vehicle ski
 🛰️ satellite communication gps orbit spaceflight NASA ISS
-🚀 rocket launch ship staffmode NASA outer space outer_space fly
-🛸 flying_saucer transportation vehicle ufo
-🛎️ bellhop_bell service
+🚀 rocket launch ship staffmode NASA outer space outer space fly
+🛸 flying saucer transportation vehicle ufo
+🛎️ bellhop bell service
 🧳 luggage packing travel
-⌛ hourglass_done time clock oldschool limit exam quiz test
-⏳ hourglass_not_done oldschool time countdown
+⌛ hourglass done time clock oldschool limit exam quiz test
+⏳ hourglass not done oldschool time countdown
 ⌚ watch time accessories
-⏰ alarm_clock time wake
+⏰ alarm clock time wake
 ⏱️ stopwatch time deadline
-⏲️ timer_clock alarm
-🕰️ mantelpiece_clock time
-🕛 twelve_o_clock time noon midnight midday late early schedule
-🕧 twelve_thirty time late early schedule
-🕐 one_o_clock time late early schedule
-🕜 one_thirty time late early schedule
-🕑 two_o_clock time late early schedule
-🕝 two_thirty time late early schedule
-🕒 three_o_clock time late early schedule
-🕞 three_thirty time late early schedule
-🕓 four_o_clock time late early schedule
-🕟 four_thirty time late early schedule
-🕔 five_o_clock time late early schedule
-🕠 five_thirty time late early schedule
-🕕 six_o_clock time late early schedule dawn dusk
-🕡 six_thirty time late early schedule
-🕖 seven_o_clock time late early schedule
-🕢 seven_thirty time late early schedule
-🕗 eight_o_clock time late early schedule
-🕣 eight_thirty time late early schedule
-🕘 nine_o_clock time late early schedule
-🕤 nine_thirty time late early schedule
-🕙 ten_o_clock time late early schedule
-🕥 ten_thirty time late early schedule
-🕚 eleven_o_clock time late early schedule
-🕦 eleven_thirty time late early schedule
-🌑 new_moon nature twilight planet space night evening sleep
-🌒 waxing_crescent_moon nature twilight planet space night evening sleep
-🌓 first_quarter_moon nature twilight planet space night evening sleep
-🌔 waxing_gibbous_moon nature night sky gray twilight planet space evening sleep
-🌕 full_moon nature yellow twilight planet space night evening sleep
-🌖 waning_gibbous_moon nature twilight planet space night evening sleep waxing_gibbous_moon
-🌗 last_quarter_moon nature twilight planet space night evening sleep
-🌘 waning_crescent_moon nature twilight planet space night evening sleep
-🌙 crescent_moon night sleep sky evening magic
-🌚 new_moon_face nature twilight planet space night evening sleep
-🌛 first_quarter_moon_face nature twilight planet space night evening sleep
-🌜 last_quarter_moon_face nature twilight planet space night evening sleep
+⏲️ timer clock alarm
+🕰️ mantelpiece clock time
+🕛 twelve o clock time noon midnight midday late early schedule
+🕧 twelve thirty time late early schedule
+🕐 one o clock time late early schedule
+🕜 one thirty time late early schedule
+🕑 two o clock time late early schedule
+🕝 two thirty time late early schedule
+🕒 three o clock time late early schedule
+🕞 three thirty time late early schedule
+🕓 four o clock time late early schedule
+🕟 four thirty time late early schedule
+🕔 five o clock time late early schedule
+🕠 five thirty time late early schedule
+🕕 six o clock time late early schedule dawn dusk
+🕡 six thirty time late early schedule
+🕖 seven o clock time late early schedule
+🕢 seven thirty time late early schedule
+🕗 eight o clock time late early schedule
+🕣 eight thirty time late early schedule
+🕘 nine o clock time late early schedule
+🕤 nine thirty time late early schedule
+🕙 ten o clock time late early schedule
+🕥 ten thirty time late early schedule
+🕚 eleven o clock time late early schedule
+🕦 eleven thirty time late early schedule
+🌑 new moon nature twilight planet space night evening sleep
+🌒 waxing crescent moon nature twilight planet space night evening sleep
+🌓 first quarter moon nature twilight planet space night evening sleep
+🌔 waxing gibbous moon nature night sky gray twilight planet space evening sleep
+🌕 full moon nature yellow twilight planet space night evening sleep
+🌖 waning gibbous moon nature twilight planet space night evening sleep waxing gibbous moon
+🌗 last quarter moon nature twilight planet space night evening sleep
+🌘 waning crescent moon nature twilight planet space night evening sleep
+🌙 crescent moon night sleep sky evening magic
+🌚 new moon face nature twilight planet space night evening sleep
+🌛 first quarter moon face nature twilight planet space night evening sleep
+🌜 last quarter moon face nature twilight planet space night evening sleep
 🌡️ thermometer weather temperature hot cold
 ☀️ sun weather nature brightness summer beach spring
-🌝 full_moon_face nature twilight planet space night evening sleep
-🌞 sun_with_face nature morning sky
-🪐 ringed_planet outerspace
+🌝 full moon face nature twilight planet space night evening sleep
+🌞 sun with face nature morning sky
+🪐 ringed planet outerspace
 ⭐ star night yellow
-🌟 glowing_star night sparkle awesome good magic
-🌠 shooting_star night photo
-🌌 milky_way photo space stars
+🌟 glowing star night sparkle awesome good magic
+🌠 shooting star night photo
+🌌 milky way photo space stars
 ☁️ cloud weather sky
-⛅ sun_behind_cloud weather nature cloudy morning fall spring
-⛈️ cloud_with_lightning_and_rain weather lightning
-🌤️ sun_behind_small_cloud weather
-🌥️ sun_behind_large_cloud weather
-🌦️ sun_behind_rain_cloud weather
-🌧️ cloud_with_rain weather
-🌨️ cloud_with_snow weather
-🌩️ cloud_with_lightning weather thunder
+⛅ sun behind cloud weather nature cloudy morning fall spring
+⛈️ cloud with lightning and rain weather lightning
+🌤️ sun behind small cloud weather
+🌥️ sun behind large cloud weather
+🌦️ sun behind rain cloud weather
+🌧️ cloud with rain weather
+🌨️ cloud with snow weather
+🌩️ cloud with lightning weather thunder
 🌪️ tornado weather cyclone twister
 🌫️ fog weather
-🌬️ wind_face gust air
+🌬️ wind face gust air
 🌀 cyclone weather swirl blue cloud vortex spiral whirlpool spin tornado hurricane typhoon
-🌈 rainbow nature happy unicorn_face photo sky spring
-🌂 closed_umbrella weather rain drizzle
+🌈 rainbow nature happy unicorn face photo sky spring
+🌂 closed umbrella weather rain drizzle
 ☂️ umbrella weather spring
-☔ umbrella_with_rain_drops rainy weather spring
-⛱️ umbrella_on_ground weather summer
-⚡ high_voltage thunder weather lightning bolt fast
+☔ umbrella with rain drops rainy weather spring
+⛱️ umbrella on ground weather summer
+⚡ high voltage thunder weather lightning bolt fast
 ❄️ snowflake winter season cold weather christmas xmas
 ☃️ snowman winter season cold weather christmas xmas frozen
-⛄ snowman_without_snow winter season cold weather christmas xmas frozen without_snow
+⛄ snowman without snow winter season cold weather christmas xmas frozen without snow
 ☄️ comet space
 🔥 fire hot cook flame
 💧 droplet water drip faucet spring
-🌊 water_wave sea water wave nature tsunami disaster
-🎃 jack_o_lantern halloween light pumpkin creepy fall
-🎄 christmas_tree festival vacation december xmas celebration
+🌊 water wave sea water wave nature tsunami disaster
+🎃 jack o lantern halloween light pumpkin creepy fall
+🎄 christmas tree festival vacation december xmas celebration
 🎆 fireworks photo festival carnival congratulations
 🎇 sparkler stars night shine
 🧨 firecracker dynamite boom explode explosion explosive
 ✨ sparkles stars shine shiny cool awesome good magic
 🎈 balloon party celebration birthday circus
-🎉 party_popper party congratulations birthday magic circus celebration tada
-🎊 confetti_ball festival party birthday circus
-🎋 tanabata_tree plant nature branch summer
-🎍 pine_decoration plant nature vegetable panda pine_decoration
-🎎 japanese_dolls japanese toy kimono
-🎏 carp_streamer fish japanese koinobori carp banner
-🎐 wind_chime nature ding spring bell
-🎑 moon_viewing_ceremony photo japan asia tsukimi
-🧧 red_envelope gift
+🎉 party popper party congratulations birthday magic circus celebration tada
+🎊 confetti ball festival party birthday circus
+🎋 tanabata tree plant nature branch summer
+🎍 pine decoration plant nature vegetable panda pine decoration
+🎎 japanese dolls japanese toy kimono
+🎏 carp streamer fish japanese koinobori carp banner
+🎐 wind chime nature ding spring bell
+🎑 moon viewing ceremony photo japan asia tsukimi
+🧧 red envelope gift
 🎀 ribbon decoration pink girl bowtie
-🎁 wrapped_gift present birthday christmas xmas
-🎗️ reminder_ribbon sports cause support awareness
-🎟️ admission_tickets sports concert entrance
+🎁 wrapped gift present birthday christmas xmas
+🎗️ reminder ribbon sports cause support awareness
+🎟️ admission tickets sports concert entrance
 🎫 ticket event concert pass
-🎖️ military_medal award winning army
+🎖️ military medal award winning army
 🏆 trophy win award contest place ftw ceremony
-🏅 sports_medal award winning
-🥇 1st_place_medal award winning first
-🥈 2nd_place_medal award second
-🥉 3rd_place_medal award third
-⚽ soccer_ball sports football
+🏅 sports medal award winning
+🥇 1st place medal award winning first
+🥈 2nd place medal award second
+🥉 3rd place medal award third
+⚽ soccer ball sports football
 ⚾ baseball sports balls
 🥎 softball sports balls
 🏀 basketball sports balls NBA
 🏐 volleyball sports balls
-🏈 american_football sports balls NFL
-🏉 rugby_football sports team
+🏈 american football sports balls NFL
+🏉 rugby football sports team
 🎾 tennis sports balls green
-🥏 flying_disc sports frisbee ultimate
+🥏 flying disc sports frisbee ultimate
 🎳 bowling sports fun play
-🏏 cricket_game sports
-🏑 field_hockey sports
-🏒 ice_hockey sports
+🏏 cricket game sports
+🏑 field hockey sports
+🏒 ice hockey sports
 🥍 lacrosse sports ball stick
-🏓 ping_pong sports pingpong
+🏓 ping pong sports pingpong
 🏸 badminton sports
-🥊 boxing_glove sports fighting
-🥋 martial_arts_uniform judo karate taekwondo
-🥅 goal_net sports
-⛳ flag_in_hole sports business flag hole summer
-⛸️ ice_skate sports
-🎣 fishing_pole food hobby summer
-🤿 diving_mask sport ocean
-🎽 running_shirt play pageant
+🥊 boxing glove sports fighting
+🥋 martial arts uniform judo karate taekwondo
+🥅 goal net sports
+⛳ flag in hole sports business flag hole summer
+⛸️ ice skate sports
+🎣 fishing pole food hobby summer
+🤿 diving mask sport ocean
+🎽 running shirt play pageant
 🎿 skis sports winter cold snow
 🛷 sled sleigh luge toboggan
-🥌 curling_stone sports
-🎯 direct_hit game play bar target bullseye
-🪀 yo_yo toy
+🥌 curling stone sports
+🎯 direct hit game play bar target bullseye
+🪀 yo yo toy
 🪁 kite wind fly
-🎱 pool_8_ball pool hobby game luck magic
-🔮 crystal_ball disco party magic circus fortune_teller
-🧿 nazar_amulet bead charm
-🎮 video_game play console PS4 controller
+🎱 pool 8 ball pool hobby game luck magic
+🔮 crystal ball disco party magic circus fortune teller
+🧿 nazar amulet bead charm
+🎮 video game play console PS4 controller
 🕹️ joystick game play
-🎰 slot_machine bet gamble vegas fruit machine luck casino
-🎲 game_die dice random tabletop play luck
-🧩 puzzle_piece interlocking puzzle piece
-🧸 teddy_bear plush stuffed
-♠️ spade_suit poker cards suits magic
-♥️ heart_suit poker cards magic suits
-♦️ diamond_suit poker cards magic suits
-♣️ club_suit poker cards magic suits
-♟️ chess_pawn expendable
+🎰 slot machine bet gamble vegas fruit machine luck casino
+🎲 game die dice random tabletop play luck
+🧩 puzzle piece interlocking puzzle piece
+🧸 teddy bear plush stuffed
+♠️ spade suit poker cards suits magic
+♥️ heart suit poker cards magic suits
+♦️ diamond suit poker cards magic suits
+♣️ club suit poker cards magic suits
+♟️ chess pawn expendable
 🃏 joker poker cards game play magic
-🀄 mahjong_red_dragon game play chinese kanji
-🎴 flower_playing_cards game sunset red
-🎭 performing_arts acting theater drama
-🖼️ framed_picture photography
-🎨 artist_palette design paint draw colors
+🀄 mahjong red dragon game play chinese kanji
+🎴 flower playing cards game sunset red
+🎭 performing arts acting theater drama
+🖼️ framed picture photography
+🎨 artist palette design paint draw colors
 🧵 thread needle sewing spool string
 🧶 yarn ball crochet knit
 👓 glasses fashion accessories eyesight nerdy dork geek
 🕶️ sunglasses face cool accessories
 🥽 goggles eyes protection safety
-🥼 lab_coat doctor experiment scientist chemist
-🦺 safety_vest protection
+🥼 lab coat doctor experiment scientist chemist
+🦺 safety vest protection
 👔 necktie shirt suitup formal fashion cloth business
-👕 t_shirt fashion cloth casual shirt tee
+👕 t shirt fashion cloth casual shirt tee
 👖 jeans fashion shopping
 🧣 scarf neck winter clothes
 🧤 gloves hands winter clothes
@@ -1037,283 +1037,283 @@ exit
 👗 dress clothes fashion shopping
 👘 kimono dress fashion women female japanese
 🥻 sari dress
-🩱 one_piece_swimsuit fashion
+🩱 one piece swimsuit fashion
 🩲 briefs clothing
 🩳 shorts clothing
 👙 bikini swimming female woman girl fashion beach summer
-👚 woman_s_clothes fashion shopping_bags female
+👚 woman s clothes fashion shopping bags female
 👛 purse fashion accessories money sales shopping
 👜 handbag fashion accessory accessories shopping
-👝 clutch_bag bag accessories shopping
-🛍️ shopping_bags mall buy purchase
+👝 clutch bag bag accessories shopping
+🛍️ shopping bags mall buy purchase
 🎒 backpack student education bag backpack
-👞 man_s_shoe fashion male
-👟 running_shoe shoes sports sneakers
-🥾 hiking_boot backpacking camping hiking
-🥿 flat_shoe ballet slip-on slipper
-👠 high_heeled_shoe fashion shoes female pumps stiletto
-👡 woman_s_sandal shoes fashion flip flops
-🩰 ballet_shoes dance
-👢 woman_s_boot shoes fashion
+👞 man s shoe fashion male
+👟 running shoe shoes sports sneakers
+🥾 hiking boot backpacking camping hiking
+🥿 flat shoe ballet slip-on slipper
+👠 high heeled shoe fashion shoes female pumps stiletto
+👡 woman s sandal shoes fashion flip flops
+🩰 ballet shoes dance
+👢 woman s boot shoes fashion
 👑 crown king kod leader royalty lord
-👒 woman_s_hat fashion accessories female lady spring
-🎩 top_hat magic gentleman classy circus
-🎓 graduation_cap school college degree university graduation cap hat legal learn education
-🧢 billed_cap cap baseball
-⛑️ rescue_worker_s_helmet construction build
-📿 prayer_beads dhikr religious
+👒 woman s hat fashion accessories female lady spring
+🎩 top hat magic gentleman classy circus
+🎓 graduation cap school college degree university graduation cap hat legal learn education
+🧢 billed cap cap baseball
+⛑️ rescue worker s helmet construction build
+📿 prayer beads dhikr religious
 💄 lipstick female girl fashion woman
 💍 ring wedding propose marriage valentines diamond fashion jewelry gem engagement
-💎 gem_stone blue ruby diamond jewelry
-🔇 muted_speaker sound volume silence quiet
-🔈 speaker_low_volume sound volume silence broadcast
-🔉 speaker_medium_volume volume speaker broadcast
-🔊 speaker_high_volume volume noise noisy speaker broadcast
+💎 gem stone blue ruby diamond jewelry
+🔇 muted speaker sound volume silence quiet
+🔈 speaker low volume sound volume silence broadcast
+🔉 speaker medium volume volume speaker broadcast
+🔊 speaker high volume volume noise noisy speaker broadcast
 📢 loudspeaker volume sound
 📣 megaphone sound speaker volume
-📯 postal_horn instrument music
+📯 postal horn instrument music
 🔔 bell sound notification christmas xmas chime
-🔕 bell_with_slash sound volume mute quiet silent
-🎼 musical_score treble clef compose
-🎵 musical_note score tone sound
-🎶 musical_notes music score
-🎙️ studio_microphone sing recording artist talkshow
-🎚️ level_slider scale
-🎛️ control_knobs dial
+🔕 bell with slash sound volume mute quiet silent
+🎼 musical score treble clef compose
+🎵 musical note score tone sound
+🎶 musical notes music score
+🎙️ studio microphone sing recording artist talkshow
+🎚️ level slider scale
+🎛️ control knobs dial
 🎤 microphone sound music PA sing talkshow
 🎧 headphone music score gadgets
 📻 radio communication music podcast program
 🎷 saxophone music instrument jazz blues
 🎸 guitar music instrument
-🎹 musical_keyboard piano instrument compose
+🎹 musical keyboard piano instrument compose
 🎺 trumpet music brass
 🎻 violin music instrument orchestra symphony
 🪕 banjo music instructment
 🥁 drum music instrument drumsticks snare
-📱 mobile_phone technology apple gadgets dial
-📲 mobile_phone_with_arrow iphone incoming
+📱 mobile phone technology apple gadgets dial
+📲 mobile phone with arrow iphone incoming
 ☎️ telephone technology communication dial telephone
-📞 telephone_receiver technology communication dial
+📞 telephone receiver technology communication dial
 📟 pager bbcall oldschool 90s
-📠 fax_machine communication technology
+📠 fax machine communication technology
 🔋 battery power energy sustain
-🔌 electric_plug charger power
+🔌 electric plug charger power
 💻 laptop technology laptop screen display monitor
-🖥️ desktop_computer technology computing screen
+🖥️ desktop computer technology computing screen
 🖨️ printer paper ink
 ⌨️ keyboard technology computer type input text
-🖱️ computer_mouse click
+🖱️ computer mouse click
 🖲️ trackball technology trackpad
-💽 computer_disk technology record data disk 90s
-💾 floppy_disk oldschool technology save 90s 80s
-💿 optical_disk technology dvd disk disc 90s
+💽 computer disk technology record data disk 90s
+💾 floppy disk oldschool technology save 90s 80s
+💿 optical disk technology dvd disk disc 90s
 📀 dvd cd disk disc
 🧮 abacus calculation
-🎥 movie_camera film record
-🎞️ film_frames movie
-📽️ film_projector video tape record movie
-🎬 clapper_board movie film record
+🎥 movie camera film record
+🎞️ film frames movie
+📽️ film projector video tape record movie
+🎬 clapper board movie film record
 📺 television technology program oldschool show television
 📷 camera gadgets photography
-📸 camera_with_flash photography gadgets
-📹 video_camera film record
+📸 camera with flash photography gadgets
+📹 video camera film record
 📼 videocassette record video oldschool 90s 80s
-🔍 magnifying_glass_tilted_left search zoom find detective
-🔎 magnifying_glass_tilted_right search zoom find detective
+🔍 magnifying glass tilted left search zoom find detective
+🔎 magnifying glass tilted right search zoom find detective
 🕯️ candle fire wax
-💡 light_bulb light electricity idea
+💡 light bulb light electricity idea
 🔦 flashlight dark camping sight night
-🏮 red_paper_lantern light paper halloween spooky
-🪔 diya_lamp lighting
-📔 notebook_with_decorative_cover classroom notes record paper study
-📕 closed_book read library knowledge textbook learn
-📖 open_book book read library knowledge literature learn study
-📗 green_book read library knowledge study
-📘 blue_book read library knowledge learn study
-📙 orange_book read library knowledge textbook study
+🏮 red paper lantern light paper halloween spooky
+🪔 diya lamp lighting
+📔 notebook with decorative cover classroom notes record paper study
+📕 closed book read library knowledge textbook learn
+📖 open book book read library knowledge literature learn study
+📗 green book read library knowledge study
+📘 blue book read library knowledge learn study
+📙 orange book read library knowledge textbook study
 📚 books literature library study
 📓 notebook stationery record notes paper study
 📒 ledger notes paper
-📃 page_with_curl documents office paper
+📃 page with curl documents office paper
 📜 scroll documents ancient history paper
-📄 page_facing_up documents office paper information
+📄 page facing up documents office paper information
 📰 newspaper press headline
-🗞️ rolled_up_newspaper press headline
-📑 bookmark_tabs favorite save order tidy
+🗞️ rolled up newspaper press headline
+📑 bookmark tabs favorite save order tidy
 🔖 bookmark favorite label save
 🏷️ label sale tag
-💰 money_bag dollar payment coins sale
-💴 yen_banknote money sales japanese dollar currency
-💵 dollar_banknote money sales bill currency
-💶 euro_banknote money sales dollar currency
-💷 pound_banknote british sterling money sales bills uk england currency
-💸 money_with_wings dollar bills payment sale
-💳 credit_card money sales dollar bill payment shopping
+💰 money bag dollar payment coins sale
+💴 yen banknote money sales japanese dollar currency
+💵 dollar banknote money sales bill currency
+💶 euro banknote money sales dollar currency
+💷 pound banknote british sterling money sales bills uk england currency
+💸 money with wings dollar bills payment sale
+💳 credit card money sales dollar bill payment shopping
 🧾 receipt accounting expenses
-💹 chart_increasing_with_yen green-square graph presentation stats
-💱 currency_exchange money sales dollar travel
-💲 heavy_dollar_sign money sales payment currency buck
+💹 chart increasing with yen green-square graph presentation stats
+💱 currency exchange money sales dollar travel
+💲 heavy dollar sign money sales payment currency buck
 ✉️ envelope letter postal inbox communication
-📧 e_mail communication inbox
-📨 incoming_envelope email inbox
-📩 envelope_with_arrow email communication
-📤 outbox_tray inbox email
-📥 inbox_tray email documents
+📧 e mail communication inbox
+📨 incoming envelope email inbox
+📩 envelope with arrow email communication
+📤 outbox tray inbox email
+📥 inbox tray email documents
 📦 package mail gift cardboard box moving
-📫 closed_mailbox_with_raised_flag email inbox communication
-📪 closed_mailbox_with_lowered_flag email communication inbox
-📬 open_mailbox_with_raised_flag email inbox communication
-📭 open_mailbox_with_lowered_flag email inbox
+📫 closed mailbox with raised flag email inbox communication
+📪 closed mailbox with lowered flag email communication inbox
+📬 open mailbox with raised flag email inbox communication
+📭 open mailbox with lowered flag email inbox
 📮 postbox email letter envelope
-🗳️ ballot_box_with_ballot election vote
+🗳️ ballot box with ballot election vote
 ✏️ pencil stationery write paper writing school study
-✒️ black_nib pen stationery writing write
-🖋️ fountain_pen stationery writing write
+✒️ black nib pen stationery writing write
+🖋️ fountain pen stationery writing write
 🖊️ pen stationery writing write
 🖌️ paintbrush drawing creativity art
 🖍️ crayon drawing creativity
 📝 memo write documents stationery pencil paper writing legal exam quiz test study compose
 💼 briefcase business documents work law legal job career
-📁 file_folder documents business office
-📂 open_file_folder documents load
-🗂️ card_index_dividers organizing business stationery
+📁 file folder documents business office
+📂 open file folder documents load
+🗂️ card index dividers organizing business stationery
 📅 calendar calendar schedule
-📆 tear_off_calendar schedule date planning
-🗒️ spiral_notepad memo stationery
-🗓️ spiral_calendar date schedule planning
-📇 card_index business stationery
-📈 chart_increasing graph presentation stats recovery business economics money sales good success
-📉 chart_decreasing graph presentation stats recession business economics money sales bad failure
-📊 bar_chart graph presentation stats
+📆 tear off calendar schedule date planning
+🗒️ spiral notepad memo stationery
+🗓️ spiral calendar date schedule planning
+📇 card index business stationery
+📈 chart increasing graph presentation stats recovery business economics money sales good success
+📉 chart decreasing graph presentation stats recession business economics money sales bad failure
+📊 bar chart graph presentation stats
 📋 clipboard stationery documents
 📌 pushpin stationery mark here
-📍 round_pushpin stationery location map here
+📍 round pushpin stationery location map here
 📎 paperclip documents stationery
-🖇️ linked_paperclips documents stationery
-📏 straight_ruler stationery calculate length math school drawing architect sketch
-📐 triangular_ruler stationery math architect sketch
+🖇️ linked paperclips documents stationery
+📏 straight ruler stationery calculate length math school drawing architect sketch
+📐 triangular ruler stationery math architect sketch
 ✂️ scissors stationery cut
-🗃️ card_file_box business stationery
-🗄️ file_cabinet filing organizing
+🗃️ card file box business stationery
+🗄️ file cabinet filing organizing
 🗑️ wastebasket bin trash rubbish garbage toss
 🔒 locked security password padlock
 🔓 unlocked privacy security
-🔏 locked_with_pen security secret
-🔐 locked_with_key security privacy
+🔏 locked with pen security secret
+🔐 locked with key security privacy
 🔑 key lock door password
-🗝️ old_key lock door password
+🗝️ old key lock door password
 🔨 hammer tools build create
 🪓 axe tool chop cut
 ⛏️ pick tools dig
-⚒️ hammer_and_pick tools build create
-🛠️ hammer_and_wrench tools build create
+⚒️ hammer and pick tools build create
+🛠️ hammer and wrench tools build create
 🗡️ dagger weapon
-⚔️ crossed_swords weapon
+⚔️ crossed swords weapon
 🔫 pistol violence weapon pistol revolver
-🏹 bow_and_arrow sports
+🏹 bow and arrow sports
 🛡️ shield protection security
 🔧 wrench tools diy ikea fix maintainer
-🔩 nut_and_bolt handy tools fix
+🔩 nut and bolt handy tools fix
 ⚙️ gear cog
 🗜️ clamp tool
-⚖️ balance_scale law fairness weight
-🦯 probing_cane accessibility
+⚖️ balance scale law fairness weight
+🦯 probing cane accessibility
 🔗 link rings url
 ⛓️ chains lock arrest
 🧰 toolbox tools diy fix maintainer mechanic
 🧲 magnet attraction magnetic
 ⚗️ alembic distilling science experiment chemistry
-🧪 test_tube chemistry experiment lab science
-🧫 petri_dish bacteria biology culture lab
+🧪 test tube chemistry experiment lab science
+🧫 petri dish bacteria biology culture lab
 🧬 dna biologist genetics life
 🔬 microscope laboratory experiment zoomin science study
 🔭 telescope stars space zoom science astronomy
-📡 satellite_antenna communication future radio space
+📡 satellite antenna communication future radio space
 💉 syringe health hospital drugs blood medicine needle doctor nurse
-🩸 drop_of_blood period hurt harm wound
+🩸 drop of blood period hurt harm wound
 💊 pill health medicine doctor pharmacy drug
-🩹 adhesive_bandage heal
+🩹 adhesive bandage heal
 🩺 stethoscope health
 🚪 door house entry exit
 🛏️ bed sleep rest
-🛋️ couch_and_lamp read chill
+🛋️ couch and lamp read chill
 🪑 chair sit furniture
 🚽 toilet restroom wc washroom bathroom potty
 🚿 shower clean water bathroom
 🛁 bathtub clean shower bathroom
 🪒 razor cut
-🧴 lotion_bottle moisturizer sunscreen
-🧷 safety_pin diaper
+🧴 lotion bottle moisturizer sunscreen
+🧷 safety pin diaper
 🧹 broom cleaning sweeping witch
 🧺 basket laundry
-🧻 roll_of_paper roll
+🧻 roll of paper roll
 🧼 soap bar bathing cleaning lather
 🧽 sponge absorbing cleaning porous
-🧯 fire_extinguisher quench
-🛒 shopping_cart trolley
+🧯 fire extinguisher quench
+🛒 shopping cart trolley
 🚬 cigarette kills tobacco cigarette joint smoke
 ⚰️ coffin vampire dead die death rip graveyard cemetery casket funeral box
-⚱️ funeral_urn dead die death rip ashes
+⚱️ funeral urn dead die death rip ashes
 🗿 moai rock easter island moai
-🏧 atm_sign money sales cash blue-square payment bank
-🚮 litter_in_bin_sign blue-square sign human info
-🚰 potable_water blue-square liquid restroom cleaning faucet
-♿ wheelchair_symbol blue-square disabled accessibility
-🚹 men_s_room toilet restroom wc blue-square gender male
-🚺 women_s_room purple-square woman female toilet loo restroom gender
+🏧 atm sign money sales cash blue-square payment bank
+🚮 litter in bin sign blue-square sign human info
+🚰 potable water blue-square liquid restroom cleaning faucet
+♿ wheelchair symbol blue-square disabled accessibility
+🚹 men s room toilet restroom wc blue-square gender male
+🚺 women s room purple-square woman female toilet loo restroom gender
 🚻 restroom blue-square toilet refresh wc gender
-🚼 baby_symbol orange-square child
-🚾 water_closet toilet restroom blue-square
-🛂 passport_control custom blue-square
+🚼 baby symbol orange-square child
+🚾 water closet toilet restroom blue-square
+🛂 passport control custom blue-square
 🛃 customs passport border blue-square
-🛄 baggage_claim blue-square airport transport
-🛅 left_luggage blue-square travel
+🛄 baggage claim blue-square airport transport
+🛅 left luggage blue-square travel
 ⚠️ warning exclamation wip alert error problem issue
-🚸 children_crossing school warning danger sign driving yellow-diamond
-⛔ no_entry limit security privacy bad denied stop circle
+🚸 children crossing school warning danger sign driving yellow-diamond
+⛔ no entry limit security privacy bad denied stop circle
 🚫 prohibited forbid stop limit denied disallow circle
-🚳 no_bicycles cyclist prohibited circle
-🚭 no_smoking cigarette blue-square smell smoke
-🚯 no_littering trash bin garbage circle
-🚱 non_potable_water drink faucet tap circle
-🚷 no_pedestrians rules crossing walking circle
-📵 no_mobile_phones iphone mute circle
-🔞 no_one_under_eighteen 18 drink pub night minor circle
+🚳 no bicycles cyclist prohibited circle
+🚭 no smoking cigarette blue-square smell smoke
+🚯 no littering trash bin garbage circle
+🚱 non potable water drink faucet tap circle
+🚷 no pedestrians rules crossing walking circle
+📵 no mobile phones iphone mute circle
+🔞 no one under eighteen 18 drink pub night minor circle
 ☢️ radioactive nuclear danger
 ☣️ biohazard danger
-⬆️ up_arrow blue-square continue top direction
-↗️ up_right_arrow blue-square point direction diagonal northeast
-➡️ right_arrow blue-square next
-↘️ down_right_arrow blue-square direction diagonal southeast
-⬇️ down_arrow blue-square direction bottom
-↙️ down_left_arrow blue-square direction diagonal southwest
-⬅️ left_arrow blue-square previous back
-↖️ up_left_arrow blue-square point direction diagonal northwest
-↕️ up_down_arrow blue-square direction way vertical
-↔️ left_right_arrow shape direction horizontal sideways
-↩️ right_arrow_curving_left back return blue-square undo enter
-↪️ left_arrow_curving_right blue-square return rotate direction
-⤴️ right_arrow_curving_up blue-square direction top
-⤵️ right_arrow_curving_down blue-square direction bottom
-🔃 clockwise_vertical_arrows sync cycle round repeat
-🔄 counterclockwise_arrows_button blue-square sync cycle
-🔙 back_arrow arrow words return
-🔚 end_arrow words arrow
-🔛 on_arrow arrow words
-🔜 soon_arrow arrow words
-🔝 top_arrow words blue-square
-🛐 place_of_worship religion church temple prayer
-⚛️ atom_symbol science physics chemistry
+⬆️ up arrow blue-square continue top direction
+↗️ up right arrow blue-square point direction diagonal northeast
+➡️ right arrow blue-square next
+↘️ down right arrow blue-square direction diagonal southeast
+⬇️ down arrow blue-square direction bottom
+↙️ down left arrow blue-square direction diagonal southwest
+⬅️ left arrow blue-square previous back
+↖️ up left arrow blue-square point direction diagonal northwest
+↕️ up down arrow blue-square direction way vertical
+↔️ left right arrow shape direction horizontal sideways
+↩️ right arrow curving left back return blue-square undo enter
+↪️ left arrow curving right blue-square return rotate direction
+⤴️ right arrow curving up blue-square direction top
+⤵️ right arrow curving down blue-square direction bottom
+🔃 clockwise vertical arrows sync cycle round repeat
+🔄 counterclockwise arrows button blue-square sync cycle
+🔙 back arrow arrow words return
+🔚 end arrow words arrow
+🔛 on arrow arrow words
+🔜 soon arrow arrow words
+🔝 top arrow words blue-square
+🛐 place of worship religion church temple prayer
+⚛️ atom symbol science physics chemistry
 🕉️ om hinduism buddhism sikhism jainism
-✡️ star_of_david judaism
-☸️ wheel_of_dharma hinduism buddhism sikhism jainism
-☯️ yin_yang balance
-✝️ latin_cross christianity
-☦️ orthodox_cross suppedaneum religion
-☪️ star_and_crescent islam
-☮️ peace_symbol hippie
+✡️ star of david judaism
+☸️ wheel of dharma hinduism buddhism sikhism jainism
+☯️ yin yang balance
+✝️ latin cross christianity
+☦️ orthodox cross suppedaneum religion
+☪️ star and crescent islam
+☮️ peace symbol hippie
 🕎 menorah hanukkah candles jewish
-🔯 dotted_six_pointed_star purple-square religion jewish hexagram
+🔯 dotted six pointed star purple-square religion jewish hexagram
 ♈ aries sign purple-square zodiac astrology
 ♉ taurus purple-square sign zodiac astrology
 ♊ gemini sign zodiac purple-square astrology
@@ -1327,419 +1327,419 @@ exit
 ♒ aquarius sign purple-square zodiac astrology
 ♓ pisces purple-square sign zodiac astrology
 ⛎ ophiuchus sign purple-square constellation astrology
-🔀 shuffle_tracks_button blue-square shuffle music random
-🔁 repeat_button loop record
-🔂 repeat_single_button blue-square loop
-▶️ play_button blue-square right direction play
-⏩ fast_forward_button blue-square play speed continue
-⏭️ next_track_button forward next blue-square
-⏯️ play_or_pause_button blue-square play pause
-◀️ reverse_button blue-square left direction
-⏪ fast_reverse_button play blue-square
-⏮️ last_track_button backward
-🔼 upwards_button blue-square triangle direction point forward top
-⏫ fast_up_button blue-square direction top
-🔽 downwards_button blue-square direction bottom
-⏬ fast_down_button blue-square direction bottom
-⏸️ pause_button pause blue-square
-⏹️ stop_button blue-square
-⏺️ record_button blue-square
-⏏️ eject_button blue-square
+🔀 shuffle tracks button blue-square shuffle music random
+🔁 repeat button loop record
+🔂 repeat single button blue-square loop
+▶️ play button blue-square right direction play
+⏩ fast forward button blue-square play speed continue
+⏭️ next track button forward next blue-square
+⏯️ play or pause button blue-square play pause
+◀️ reverse button blue-square left direction
+⏪ fast reverse button play blue-square
+⏮️ last track button backward
+🔼 upwards button blue-square triangle direction point forward top
+⏫ fast up button blue-square direction top
+🔽 downwards button blue-square direction bottom
+⏬ fast down button blue-square direction bottom
+⏸️ pause button pause blue-square
+⏹️ stop button blue-square
+⏺️ record button blue-square
+⏏️ eject button blue-square
 🎦 cinema blue-square record film movie curtain stage theater
-🔅 dim_button sun afternoon warm summer
-🔆 bright_button sun light
-📶 antenna_bars blue-square reception phone internet connection wifi bluetooth bars
-📳 vibration_mode orange-square phone
-📴 mobile_phone_off mute orange-square silence quiet
-♀️ female_sign woman women lady girl
-♂️ male_sign man boy men
-⚕️ medical_symbol health hospital
+🔅 dim button sun afternoon warm summer
+🔆 bright button sun light
+📶 antenna bars blue-square reception phone internet connection wifi bluetooth bars
+📳 vibration mode orange-square phone
+📴 mobile phone off mute orange-square silence quiet
+♀️ female sign woman women lady girl
+♂️ male sign man boy men
+⚕️ medical symbol health hospital
 ♾️ infinity forever
-♻️ recycling_symbol arrow environment garbage trash
-⚜️ fleur_de_lis decorative scout
-🔱 trident_emblem weapon spear
-📛 name_badge fire forbid
-🔰 japanese_symbol_for_beginner badge shield
-⭕ hollow_red_circle circle round
-✅ check_mark_button green-square ok agree vote election answer tick
-☑️ check_box_with_check ok agree confirm black-square vote election yes tick
-✔️ check_mark ok nike answer yes tick
-✖️ multiplication_sign math calculation
-❌ cross_mark no delete remove cancel red
-❎ cross_mark_button x green-square no deny
-➕ plus_sign math calculation addition more increase
-➖ minus_sign math calculation subtract less
-➗ division_sign divide math calculation
-➰ curly_loop scribble draw shape squiggle
-➿ double_curly_loop tape cassette
-〽️ part_alternation_mark graph presentation stats business economics bad
-✳️ eight_spoked_asterisk star sparkle green-square
-✴️ eight_pointed_star orange-square shape polygon
+♻️ recycling symbol arrow environment garbage trash
+⚜️ fleur de lis decorative scout
+🔱 trident emblem weapon spear
+📛 name badge fire forbid
+🔰 japanese symbol for beginner badge shield
+⭕ hollow red circle circle round
+✅ check mark button green-square ok agree vote election answer tick
+☑️ check box with check ok agree confirm black-square vote election yes tick
+✔️ check mark ok nike answer yes tick
+✖️ multiplication sign math calculation
+❌ cross mark no delete remove cancel red
+❎ cross mark button x green-square no deny
+➕ plus sign math calculation addition more increase
+➖ minus sign math calculation subtract less
+➗ division sign divide math calculation
+➰ curly loop scribble draw shape squiggle
+➿ double curly loop tape cassette
+〽️ part alternation mark graph presentation stats business economics bad
+✳️ eight spoked asterisk star sparkle green-square
+✴️ eight pointed star orange-square shape polygon
 ❇️ sparkle stars green-square awesome good fireworks
-‼️ double_exclamation_mark exclamation surprise
-⁉️ exclamation_question_mark wat punctuation surprise
-❓ question_mark doubt confused
-❔ white_question_mark doubts gray huh confused
-❕ white_exclamation_mark surprise punctuation gray wow warning
-❗ exclamation_mark heavy_exclamation_mark danger surprise punctuation wow warning
-〰️ wavy_dash draw line moustache mustache squiggle scribble
+‼️ double exclamation mark exclamation surprise
+⁉️ exclamation question mark wat punctuation surprise
+❓ question mark doubt confused
+❔ white question mark doubts gray huh confused
+❕ white exclamation mark surprise punctuation gray wow warning
+❗ exclamation mark heavy exclamation mark danger surprise punctuation wow warning
+〰️ wavy dash draw line moustache mustache squiggle scribble
 ©️ copyright ip license circle law legal
 ®️ registered alphabet circle
-™️ trade_mark trademark brand law legal
-#️⃣ keycap_ symbol blue-square twitter
-*️⃣ keycap_ star keycap
-0️⃣ keycap_0 0 numbers blue-square null
-1️⃣ keycap_1 blue-square numbers 1
-2️⃣ keycap_2 numbers 2 prime blue-square
-3️⃣ keycap_3 3 numbers prime blue-square
-4️⃣ keycap_4 4 numbers blue-square
-5️⃣ keycap_5 5 numbers blue-square prime
-6️⃣ keycap_6 6 numbers blue-square
-7️⃣ keycap_7 7 numbers blue-square prime
-8️⃣ keycap_8 8 blue-square numbers
-9️⃣ keycap_9 blue-square numbers 9
-🔟 keycap_10 numbers 10 blue-square
-🔠 input_latin_uppercase alphabet words blue-square
-🔡 input_latin_lowercase blue-square alphabet
-🔢 input_numbers numbers blue-square
-🔣 input_symbols blue-square music note ampersand percent glyphs characters
-🔤 input_latin_letters blue-square alphabet
-🅰️ a_button red-square alphabet letter
-🆎 ab_button red-square alphabet
-🅱️ b_button red-square alphabet letter
-🆑 cl_button alphabet words red-square
-🆒 cool_button words blue-square
-🆓 free_button blue-square words
+™️ trade mark trademark brand law legal
+#️⃣ keycap  symbol blue-square twitter
+*️⃣ keycap  star keycap
+0️⃣ keycap 0 0 numbers blue-square null
+1️⃣ keycap 1 blue-square numbers 1
+2️⃣ keycap 2 numbers 2 prime blue-square
+3️⃣ keycap 3 3 numbers prime blue-square
+4️⃣ keycap 4 4 numbers blue-square
+5️⃣ keycap 5 5 numbers blue-square prime
+6️⃣ keycap 6 6 numbers blue-square
+7️⃣ keycap 7 7 numbers blue-square prime
+8️⃣ keycap 8 8 blue-square numbers
+9️⃣ keycap 9 blue-square numbers 9
+🔟 keycap 10 numbers 10 blue-square
+🔠 input latin uppercase alphabet words blue-square
+🔡 input latin lowercase blue-square alphabet
+🔢 input numbers numbers blue-square
+🔣 input symbols blue-square music note ampersand percent glyphs characters
+🔤 input latin letters blue-square alphabet
+🅰️ a button red-square alphabet letter
+🆎 ab button red-square alphabet
+🅱️ b button red-square alphabet letter
+🆑 cl button alphabet words red-square
+🆒 cool button words blue-square
+🆓 free button blue-square words
 ℹ️ information blue-square alphabet letter
-🆔 id_button purple-square words
-Ⓜ️ circled_m alphabet blue-circle letter
-🆕 new_button blue-square words start
-🆖 ng_button blue-square words shape icon
-🅾️ o_button alphabet red-square letter
-🆗 ok_button good agree yes blue-square
-🅿️ p_button cars blue-square alphabet letter
-🆘 sos_button help red-square words emergency 911
-🆙 up_button blue-square above high
-🆚 vs_button words orange-square
-🈁 japanese_here_button blue-square here katakana japanese destination
-🈂️ japanese_service_charge_button japanese blue-square katakana
-🈷️ japanese_monthly_amount_button chinese month moon japanese orange-square kanji
-🈶 japanese_not_free_of_charge_button orange-square chinese have kanji
-🈯 japanese_reserved_button chinese point green-square kanji
-🉐 japanese_bargain_button chinese kanji obtain get circle
-🈹 japanese_discount_button cut divide chinese kanji pink-square
-🈚 japanese_free_of_charge_button nothing chinese kanji japanese orange-square
-🈲 japanese_prohibited_button kanji japanese chinese forbidden limit restricted red-square
-🉑 japanese_acceptable_button ok good chinese kanji agree yes orange-circle
-🈸 japanese_application_button chinese japanese kanji orange-square
-🈴 japanese_passing_grade_button japanese chinese join kanji red-square
-🈳 japanese_vacancy_button kanji japanese chinese empty sky blue-square
-㊗️ japanese_congratulations_button chinese kanji japanese red-circle
-㊙️ japanese_secret_button privacy chinese sshh kanji red-circle
-🈺 japanese_open_for_business_button japanese opening hours orange-square
-🈵 japanese_no_vacancy_button full chinese japanese red-square kanji
-🔴 red_circle shape error danger
-🟠 orange_circle round
-🟡 yellow_circle round
-🟢 green_circle round
-🔵 blue_circle shape icon button
-🟣 purple_circle round
-🟤 brown_circle round
-⚫ black_circle shape button round
-⚪ white_circle shape round
-🟥 red_square
-🟧 orange_square
-🟨 yellow_square
-🟩 green_square
-🟦 blue_square
-🟪 purple_square
-🟫 brown_square
-⬛ black_large_square shape icon button
-⬜ white_large_square shape icon stone button
-◼️ black_medium_square shape button icon
-◻️ white_medium_square shape stone icon
-◾ black_medium_small_square icon shape button
-◽ white_medium_small_square shape stone icon button
-▪️ black_small_square shape icon
-▫️ white_small_square shape icon
-🔶 large_orange_diamond shape jewel gem
-🔷 large_blue_diamond shape jewel gem
-🔸 small_orange_diamond shape jewel gem
-🔹 small_blue_diamond shape jewel gem
-🔺 red_triangle_pointed_up shape direction up top
-🔻 red_triangle_pointed_down shape direction bottom
-💠 diamond_with_a_dot jewel blue gem crystal fancy
-🔘 radio_button input old music circle
-🔳 white_square_button shape input
-🔲 black_square_button shape input frame
-🏁 chequered_flag contest finishline race gokart
-🚩 triangular_flag mark milestone place
-🎌 crossed_flags japanese nation country border
-🏴 black_flag pirate
-🏳️ white_flag losing loser lost surrender give up fail
-🏳️‍🌈 rainbow_flag flag rainbow pride gay lgbt glbt queer homosexual lesbian bisexual transgender
-🏴‍☠️ pirate_flag skull crossbones flag banner
-🇦🇨 flag_ascension_island
-🇦🇩 flag_andorra ad flag nation country banner andorra
-🇦🇪 flag_united_arab_emirates united arab emirates flag nation country banner united_arab_emirates
-🇦🇫 flag_afghanistan af flag nation country banner afghanistan
-🇦🇬 flag_antigua_barbuda antigua barbuda flag nation country banner antigua_barbuda
-🇦🇮 flag_anguilla ai flag nation country banner anguilla
-🇦🇱 flag_albania al flag nation country banner albania
-🇦🇲 flag_armenia am flag nation country banner armenia
-🇦🇴 flag_angola ao flag nation country banner angola
-🇦🇶 flag_antarctica aq flag nation country banner antarctica
-🇦🇷 flag_argentina ar flag nation country banner argentina
-🇦🇸 flag_american_samoa american ws flag nation country banner american_samoa
-🇦🇹 flag_austria at flag nation country banner austria
-🇦🇺 flag_australia au flag nation country banner australia
-🇦🇼 flag_aruba aw flag nation country banner aruba
-🇦🇽 flag_aland_islands Åland islands flag nation country banner aland_islands
-🇦🇿 flag_azerbaijan az flag nation country banner azerbaijan
-🇧🇦 flag_bosnia_herzegovina bosnia herzegovina flag nation country banner bosnia_herzegovina
-🇧🇧 flag_barbados bb flag nation country banner barbados
-🇧🇩 flag_bangladesh bd flag nation country banner bangladesh
-🇧🇪 flag_belgium be flag nation country banner belgium
-🇧🇫 flag_burkina_faso burkina faso flag nation country banner burkina_faso
-🇧🇬 flag_bulgaria bg flag nation country banner bulgaria
-🇧🇭 flag_bahrain bh flag nation country banner bahrain
-🇧🇮 flag_burundi bi flag nation country banner burundi
-🇧🇯 flag_benin bj flag nation country banner benin
-🇧🇱 flag_st_barthelemy saint barthélemy flag nation country banner st_barthelemy
-🇧🇲 flag_bermuda bm flag nation country banner bermuda
-🇧🇳 flag_brunei bn darussalam flag nation country banner brunei
-🇧🇴 flag_bolivia bo flag nation country banner bolivia
-🇧🇶 flag_caribbean_netherlands bonaire flag nation country banner caribbean_netherlands
-🇧🇷 flag_brazil br flag nation country banner brazil
-🇧🇸 flag_bahamas bs flag nation country banner bahamas
-🇧🇹 flag_bhutan bt flag nation country banner bhutan
-🇧🇻 flag_bouvet_island norway
-🇧🇼 flag_botswana bw flag nation country banner botswana
-🇧🇾 flag_belarus by flag nation country banner belarus
-🇧🇿 flag_belize bz flag nation country banner belize
-🇨🇦 flag_canada ca flag nation country banner canada
-🇨🇨 flag_cocos_islands cocos keeling islands flag nation country banner cocos_islands
-🇨🇩 flag_congo_kinshasa congo democratic republic flag nation country banner congo_kinshasa
-🇨🇫 flag_central_african_republic central african republic flag nation country banner central_african_republic
-🇨🇬 flag_congo_brazzaville congo flag nation country banner congo_brazzaville
-🇨🇭 flag_switzerland ch flag nation country banner switzerland
-🇨🇮 flag_cote_d_ivoire ivory coast flag nation country banner cote_d_ivoire
-🇨🇰 flag_cook_islands cook islands flag nation country banner cook_islands
-🇨🇱 flag_chile flag nation country banner chile
-🇨🇲 flag_cameroon cm flag nation country banner cameroon
-🇨🇳 flag_china china chinese prc flag country nation banner china
-🇨🇴 flag_colombia co flag nation country banner colombia
-🇨🇵 flag_clipperton_island
-🇨🇷 flag_costa_rica costa rica flag nation country banner costa_rica
-🇨🇺 flag_cuba cu flag nation country banner cuba
-🇨🇻 flag_cape_verde cabo verde flag nation country banner cape_verde
-🇨🇼 flag_curacao curaçao flag nation country banner curacao
-🇨🇽 flag_christmas_island christmas island flag nation country banner christmas_island
-🇨🇾 flag_cyprus cy flag nation country banner cyprus
-🇨🇿 flag_czechia cz flag nation country banner czechia
-🇩🇪 flag_germany german nation flag country banner germany
-🇩🇬 flag_diego_garcia
-🇩🇯 flag_djibouti dj flag nation country banner djibouti
-🇩🇰 flag_denmark dk flag nation country banner denmark
-🇩🇲 flag_dominica dm flag nation country banner dominica
-🇩🇴 flag_dominican_republic dominican republic flag nation country banner dominican_republic
-🇩🇿 flag_algeria dz flag nation country banner algeria
-🇪🇦 flag_ceuta_melilla
-🇪🇨 flag_ecuador ec flag nation country banner ecuador
-🇪🇪 flag_estonia ee flag nation country banner estonia
-🇪🇬 flag_egypt eg flag nation country banner egypt
-🇪🇭 flag_western_sahara western sahara flag nation country banner western_sahara
-🇪🇷 flag_eritrea er flag nation country banner eritrea
-🇪🇸 flag_spain spain flag nation country banner spain
-🇪🇹 flag_ethiopia et flag nation country banner ethiopia
-🇪🇺 flag_european_union european union flag banner
-🇫🇮 flag_finland fi flag nation country banner finland
-🇫🇯 flag_fiji fj flag nation country banner fiji
-🇫🇰 flag_falkland_islands falkland islands malvinas flag nation country banner falkland_islands
-🇫🇲 flag_micronesia micronesia federated states flag nation country banner micronesia
-🇫🇴 flag_faroe_islands faroe islands flag nation country banner faroe_islands
-🇫🇷 flag_france banner flag nation france french country france
-🇬🇦 flag_gabon ga flag nation country banner gabon
-🇬🇧 flag_united_kingdom united kingdom great britain northern ireland flag nation country banner british UK english england union jack united_kingdom
-🇬🇩 flag_grenada gd flag nation country banner grenada
-🇬🇪 flag_georgia ge flag nation country banner georgia
-🇬🇫 flag_french_guiana french guiana flag nation country banner french_guiana
-🇬🇬 flag_guernsey gg flag nation country banner guernsey
-🇬🇭 flag_ghana gh flag nation country banner ghana
-🇬🇮 flag_gibraltar gi flag nation country banner gibraltar
-🇬🇱 flag_greenland gl flag nation country banner greenland
-🇬🇲 flag_gambia gm flag nation country banner gambia
-🇬🇳 flag_guinea gn flag nation country banner guinea
-🇬🇵 flag_guadeloupe gp flag nation country banner guadeloupe
-🇬🇶 flag_equatorial_guinea equatorial gn flag nation country banner equatorial_guinea
-🇬🇷 flag_greece gr flag nation country banner greece
-🇬🇸 flag_south_georgia_south_sandwich_islands south georgia sandwich islands flag nation country banner south_georgia_south_sandwich_islands
-🇬🇹 flag_guatemala gt flag nation country banner guatemala
-🇬🇺 flag_guam gu flag nation country banner guam
-🇬🇼 flag_guinea_bissau gw bissau flag nation country banner guinea_bissau
-🇬🇾 flag_guyana gy flag nation country banner guyana
-🇭🇰 flag_hong_kong_sar_china hong kong flag nation country banner hong_kong_sar_china
-🇭🇲 flag_heard_mcdonald_islands
-🇭🇳 flag_honduras hn flag nation country banner honduras
-🇭🇷 flag_croatia hr flag nation country banner croatia
-🇭🇹 flag_haiti ht flag nation country banner haiti
-🇭🇺 flag_hungary hu flag nation country banner hungary
-🇮🇨 flag_canary_islands canary islands flag nation country banner canary_islands
-🇮🇩 flag_indonesia flag nation country banner indonesia
-🇮🇪 flag_ireland ie flag nation country banner ireland
-🇮🇱 flag_israel il flag nation country banner israel
-🇮🇲 flag_isle_of_man isle man flag nation country banner isle_of_man
-🇮🇳 flag_india in flag nation country banner india
-🇮🇴 flag_british_indian_ocean_territory british indian ocean territory flag nation country banner british_indian_ocean_territory
-🇮🇶 flag_iraq iq flag nation country banner iraq
-🇮🇷 flag_iran iran islamic republic flag nation country banner iran
-🇮🇸 flag_iceland is flag nation country banner iceland
-🇮🇹 flag_italy italy flag nation country banner italy
-🇯🇪 flag_jersey je flag nation country banner jersey
-🇯🇲 flag_jamaica jm flag nation country banner jamaica
-🇯🇴 flag_jordan jo flag nation country banner jordan
-🇯🇵 flag_japan japanese nation flag country banner japan
-🇰🇪 flag_kenya ke flag nation country banner kenya
-🇰🇬 flag_kyrgyzstan kg flag nation country banner kyrgyzstan
-🇰🇭 flag_cambodia kh flag nation country banner cambodia
-🇰🇮 flag_kiribati ki flag nation country banner kiribati
-🇰🇲 flag_comoros km flag nation country banner comoros
-🇰🇳 flag_st_kitts_nevis saint kitts nevis flag nation country banner st_kitts_nevis
-🇰🇵 flag_north_korea north korea nation flag country banner north_korea
-🇰🇷 flag_south_korea south korea nation flag country banner south_korea
-🇰🇼 flag_kuwait kw flag nation country banner kuwait
-🇰🇾 flag_cayman_islands cayman islands flag nation country banner cayman_islands
-🇰🇿 flag_kazakhstan kz flag nation country banner kazakhstan
-🇱🇦 flag_laos lao democratic republic flag nation country banner laos
-🇱🇧 flag_lebanon lb flag nation country banner lebanon
-🇱🇨 flag_st_lucia saint lucia flag nation country banner st_lucia
-🇱🇮 flag_liechtenstein li flag nation country banner liechtenstein
-🇱🇰 flag_sri_lanka sri lanka flag nation country banner sri_lanka
-🇱🇷 flag_liberia lr flag nation country banner liberia
-🇱🇸 flag_lesotho ls flag nation country banner lesotho
-🇱🇹 flag_lithuania lt flag nation country banner lithuania
-🇱🇺 flag_luxembourg lu flag nation country banner luxembourg
-🇱🇻 flag_latvia lv flag nation country banner latvia
-🇱🇾 flag_libya ly flag nation country banner libya
-🇲🇦 flag_morocco ma flag nation country banner morocco
-🇲🇨 flag_monaco mc flag nation country banner monaco
-🇲🇩 flag_moldova moldova republic flag nation country banner moldova
-🇲🇪 flag_montenegro me flag nation country banner montenegro
-🇲🇫 flag_st_martin
-🇲🇬 flag_madagascar mg flag nation country banner madagascar
-🇲🇭 flag_marshall_islands marshall islands flag nation country banner marshall_islands
-🇲🇰 flag_north_macedonia macedonia flag nation country banner north_macedonia
-🇲🇱 flag_mali ml flag nation country banner mali
-🇲🇲 flag_myanmar mm flag nation country banner myanmar
-🇲🇳 flag_mongolia mn flag nation country banner mongolia
-🇲🇴 flag_macao_sar_china macao flag nation country banner macao_sar_china
-🇲🇵 flag_northern_mariana_islands northern mariana islands flag nation country banner northern_mariana_islands
-🇲🇶 flag_martinique mq flag nation country banner martinique
-🇲🇷 flag_mauritania mr flag nation country banner mauritania
-🇲🇸 flag_montserrat ms flag nation country banner montserrat
-🇲🇹 flag_malta mt flag nation country banner malta
-🇲🇺 flag_mauritius mu flag nation country banner mauritius
-🇲🇻 flag_maldives mv flag nation country banner maldives
-🇲🇼 flag_malawi mw flag nation country banner malawi
-🇲🇽 flag_mexico mx flag nation country banner mexico
-🇲🇾 flag_malaysia my flag nation country banner malaysia
-🇲🇿 flag_mozambique mz flag nation country banner mozambique
-🇳🇦 flag_namibia na flag nation country banner namibia
-🇳🇨 flag_new_caledonia new caledonia flag nation country banner new_caledonia
-🇳🇪 flag_niger ne flag nation country banner niger
-🇳🇫 flag_norfolk_island norfolk island flag nation country banner norfolk_island
-🇳🇬 flag_nigeria flag nation country banner nigeria
-🇳🇮 flag_nicaragua ni flag nation country banner nicaragua
-🇳🇱 flag_netherlands nl flag nation country banner netherlands
-🇳🇴 flag_norway no flag nation country banner norway
-🇳🇵 flag_nepal np flag nation country banner nepal
-🇳🇷 flag_nauru nr flag nation country banner nauru
-🇳🇺 flag_niue nu flag nation country banner niue
-🇳🇿 flag_new_zealand new zealand flag nation country banner new_zealand
-🇴🇲 flag_oman om_symbol flag nation country banner oman
-🇵🇦 flag_panama pa flag nation country banner panama
-🇵🇪 flag_peru pe flag nation country banner peru
-🇵🇫 flag_french_polynesia french polynesia flag nation country banner french_polynesia
-🇵🇬 flag_papua_new_guinea papua new guinea flag nation country banner papua_new_guinea
-🇵🇭 flag_philippines ph flag nation country banner philippines
-🇵🇰 flag_pakistan pk flag nation country banner pakistan
-🇵🇱 flag_poland pl flag nation country banner poland
-🇵🇲 flag_st_pierre_miquelon saint pierre miquelon flag nation country banner st_pierre_miquelon
-🇵🇳 flag_pitcairn_islands pitcairn flag nation country banner pitcairn_islands
-🇵🇷 flag_puerto_rico puerto rico flag nation country banner puerto_rico
-🇵🇸 flag_palestinian_territories palestine palestinian territories flag nation country banner palestinian_territories
-🇵🇹 flag_portugal pt flag nation country banner portugal
-🇵🇼 flag_palau pw flag nation country banner palau
-🇵🇾 flag_paraguay py flag nation country banner paraguay
-🇶🇦 flag_qatar qa flag nation country banner qatar
-🇷🇪 flag_reunion réunion flag nation country banner reunion
-🇷🇴 flag_romania ro flag nation country banner romania
-🇷🇸 flag_serbia rs flag nation country banner serbia
-🇷🇺 flag_russia russian federation flag nation country banner russia
-🇷🇼 flag_rwanda rw flag nation country banner rwanda
-🇸🇦 flag_saudi_arabia flag nation country banner saudi_arabia
-🇸🇧 flag_solomon_islands solomon islands flag nation country banner solomon_islands
-🇸🇨 flag_seychelles sc flag nation country banner seychelles
-🇸🇩 flag_sudan sd flag nation country banner sudan
-🇸🇪 flag_sweden se flag nation country banner sweden
-🇸🇬 flag_singapore sg flag nation country banner singapore
-🇸🇭 flag_st_helena saint helena ascension tristan cunha flag nation country banner st_helena
-🇸🇮 flag_slovenia si flag nation country banner slovenia
-🇸🇯 flag_svalbard_jan_mayen
-🇸🇰 flag_slovakia sk flag nation country banner slovakia
-🇸🇱 flag_sierra_leone sierra leone flag nation country banner sierra_leone
-🇸🇲 flag_san_marino san marino flag nation country banner san_marino
-🇸🇳 flag_senegal sn flag nation country banner senegal
-🇸🇴 flag_somalia so flag nation country banner somalia
-🇸🇷 flag_suriname sr flag nation country banner suriname
-🇸🇸 flag_south_sudan south sd flag nation country banner south_sudan
-🇸🇹 flag_sao_tome_principe sao tome principe flag nation country banner sao_tome_principe
-🇸🇻 flag_el_salvador el salvador flag nation country banner el_salvador
-🇸🇽 flag_sint_maarten sint maarten dutch flag nation country banner sint_maarten
-🇸🇾 flag_syria syrian arab republic flag nation country banner syria
-🇸🇿 flag_eswatini sz flag nation country banner eswatini
-🇹🇦 flag_tristan_da_cunha
-🇹🇨 flag_turks_caicos_islands turks caicos islands flag nation country banner turks_caicos_islands
-🇹🇩 flag_chad td flag nation country banner chad
-🇹🇫 flag_french_southern_territories french southern territories flag nation country banner french_southern_territories
-🇹🇬 flag_togo tg flag nation country banner togo
-🇹🇭 flag_thailand th flag nation country banner thailand
-🇹🇯 flag_tajikistan tj flag nation country banner tajikistan
-🇹🇰 flag_tokelau tk flag nation country banner tokelau
-🇹🇱 flag_timor_leste timor leste flag nation country banner timor_leste
-🇹🇲 flag_turkmenistan flag nation country banner turkmenistan
-🇹🇳 flag_tunisia tn flag nation country banner tunisia
-🇹🇴 flag_tonga to flag nation country banner tonga
-🇹🇷 flag_turkey turkey flag nation country banner turkey
-🇹🇹 flag_trinidad_tobago trinidad tobago flag nation country banner trinidad_tobago
-🇹🇻 flag_tuvalu flag nation country banner tuvalu
-🇹🇼 flag_taiwan tw flag nation country banner taiwan
-🇹🇿 flag_tanzania tanzania united republic flag nation country banner tanzania
-🇺🇦 flag_ukraine ua flag nation country banner ukraine
-🇺🇬 flag_uganda ug flag nation country banner uganda
-🇺🇲 flag_u_s_outlying_islands
-🇺🇳 flag_united_nations un flag banner
-🇺🇸 flag_united_states united states america flag nation country banner united_states
-🇺🇾 flag_uruguay uy flag nation country banner uruguay
-🇺🇿 flag_uzbekistan uz flag nation country banner uzbekistan
-🇻🇦 flag_vatican_city vatican city flag nation country banner vatican_city
-🇻🇨 flag_st_vincent_grenadines saint vincent grenadines flag nation country banner st_vincent_grenadines
-🇻🇪 flag_venezuela ve bolivarian republic flag nation country banner venezuela
-🇻🇬 flag_british_virgin_islands british virgin islands bvi flag nation country banner british_virgin_islands
-🇻🇮 flag_u_s_virgin_islands virgin islands us flag nation country banner u_s_virgin_islands
-🇻🇳 flag_vietnam viet nam flag nation country banner vietnam
-🇻🇺 flag_vanuatu vu flag nation country banner vanuatu
-🇼🇫 flag_wallis_futuna wallis futuna flag nation country banner wallis_futuna
-🇼🇸 flag_samoa ws flag nation country banner samoa
-🇽🇰 flag_kosovo xk flag nation country banner kosovo
-🇾🇪 flag_yemen ye flag nation country banner yemen
-🇾🇹 flag_mayotte yt flag nation country banner mayotte
-🇿🇦 flag_south_africa south africa flag nation country banner south_africa
-🇿🇲 flag_zambia zm flag nation country banner zambia
-🇿🇼 flag_zimbabwe zw flag nation country banner zimbabwe
-🏴󠁧󠁢󠁥󠁮󠁧󠁿 flag_england flag english
-🏴󠁧󠁢󠁳󠁣󠁴󠁿 flag_scotland flag scottish
-🏴󠁧󠁢󠁷󠁬󠁳󠁿 flag_wales flag welsh
+🆔 id button purple-square words
+Ⓜ️ circled m alphabet blue-circle letter
+🆕 new button blue-square words start
+🆖 ng button blue-square words shape icon
+🅾️ o button alphabet red-square letter
+🆗 ok button good agree yes blue-square
+🅿️ p button cars blue-square alphabet letter
+🆘 sos button help red-square words emergency 911
+🆙 up button blue-square above high
+🆚 vs button words orange-square
+🈁 japanese here button blue-square here katakana japanese destination
+🈂️ japanese service charge button japanese blue-square katakana
+🈷️ japanese monthly amount button chinese month moon japanese orange-square kanji
+🈶 japanese not free of charge button orange-square chinese have kanji
+🈯 japanese reserved button chinese point green-square kanji
+🉐 japanese bargain button chinese kanji obtain get circle
+🈹 japanese discount button cut divide chinese kanji pink-square
+🈚 japanese free of charge button nothing chinese kanji japanese orange-square
+🈲 japanese prohibited button kanji japanese chinese forbidden limit restricted red-square
+🉑 japanese acceptable button ok good chinese kanji agree yes orange-circle
+🈸 japanese application button chinese japanese kanji orange-square
+🈴 japanese passing grade button japanese chinese join kanji red-square
+🈳 japanese vacancy button kanji japanese chinese empty sky blue-square
+㊗️ japanese congratulations button chinese kanji japanese red-circle
+㊙️ japanese secret button privacy chinese sshh kanji red-circle
+🈺 japanese open for business button japanese opening hours orange-square
+🈵 japanese no vacancy button full chinese japanese red-square kanji
+🔴 red circle shape error danger
+🟠 orange circle round
+🟡 yellow circle round
+🟢 green circle round
+🔵 blue circle shape icon button
+🟣 purple circle round
+🟤 brown circle round
+⚫ black circle shape button round
+⚪ white circle shape round
+🟥 red square
+🟧 orange square
+🟨 yellow square
+🟩 green square
+🟦 blue square
+🟪 purple square
+🟫 brown square
+⬛ black large square shape icon button
+⬜ white large square shape icon stone button
+◼️ black medium square shape button icon
+◻️ white medium square shape stone icon
+◾ black medium small square icon shape button
+◽ white medium small square shape stone icon button
+▪️ black small square shape icon
+▫️ white small square shape icon
+🔶 large orange diamond shape jewel gem
+🔷 large blue diamond shape jewel gem
+🔸 small orange diamond shape jewel gem
+🔹 small blue diamond shape jewel gem
+🔺 red triangle pointed up shape direction up top
+🔻 red triangle pointed down shape direction bottom
+💠 diamond with a dot jewel blue gem crystal fancy
+🔘 radio button input old music circle
+🔳 white square button shape input
+🔲 black square button shape input frame
+🏁 chequered flag contest finishline race gokart
+🚩 triangular flag mark milestone place
+🎌 crossed flags japanese nation country border
+🏴 black flag pirate
+🏳️ white flag losing loser lost surrender give up fail
+🏳️‍🌈 rainbow flag flag rainbow pride gay lgbt glbt queer homosexual lesbian bisexual transgender
+🏴‍☠️ pirate flag skull crossbones flag banner
+🇦🇨 flag ascension island
+🇦🇩 flag andorra ad flag nation country banner andorra
+🇦🇪 flag united arab emirates united arab emirates flag nation country banner united arab emirates
+🇦🇫 flag afghanistan af flag nation country banner afghanistan
+🇦🇬 flag antigua barbuda antigua barbuda flag nation country banner antigua barbuda
+🇦🇮 flag anguilla ai flag nation country banner anguilla
+🇦🇱 flag albania al flag nation country banner albania
+🇦🇲 flag armenia am flag nation country banner armenia
+🇦🇴 flag angola ao flag nation country banner angola
+🇦🇶 flag antarctica aq flag nation country banner antarctica
+🇦🇷 flag argentina ar flag nation country banner argentina
+🇦🇸 flag american samoa american ws flag nation country banner american samoa
+🇦🇹 flag austria at flag nation country banner austria
+🇦🇺 flag australia au flag nation country banner australia
+🇦🇼 flag aruba aw flag nation country banner aruba
+🇦🇽 flag aland islands Åland islands flag nation country banner aland islands
+🇦🇿 flag azerbaijan az flag nation country banner azerbaijan
+🇧🇦 flag bosnia herzegovina bosnia herzegovina flag nation country banner bosnia herzegovina
+🇧🇧 flag barbados bb flag nation country banner barbados
+🇧🇩 flag bangladesh bd flag nation country banner bangladesh
+🇧🇪 flag belgium be flag nation country banner belgium
+🇧🇫 flag burkina faso burkina faso flag nation country banner burkina faso
+🇧🇬 flag bulgaria bg flag nation country banner bulgaria
+🇧🇭 flag bahrain bh flag nation country banner bahrain
+🇧🇮 flag burundi bi flag nation country banner burundi
+🇧🇯 flag benin bj flag nation country banner benin
+🇧🇱 flag st barthelemy saint barthélemy flag nation country banner st barthelemy
+🇧🇲 flag bermuda bm flag nation country banner bermuda
+🇧🇳 flag brunei bn darussalam flag nation country banner brunei
+🇧🇴 flag bolivia bo flag nation country banner bolivia
+🇧🇶 flag caribbean netherlands bonaire flag nation country banner caribbean netherlands
+🇧🇷 flag brazil br flag nation country banner brazil
+🇧🇸 flag bahamas bs flag nation country banner bahamas
+🇧🇹 flag bhutan bt flag nation country banner bhutan
+🇧🇻 flag bouvet island norway
+🇧🇼 flag botswana bw flag nation country banner botswana
+🇧🇾 flag belarus by flag nation country banner belarus
+🇧🇿 flag belize bz flag nation country banner belize
+🇨🇦 flag canada ca flag nation country banner canada
+🇨🇨 flag cocos islands cocos keeling islands flag nation country banner cocos islands
+🇨🇩 flag congo kinshasa congo democratic republic flag nation country banner congo kinshasa
+🇨🇫 flag central african republic central african republic flag nation country banner central african republic
+🇨🇬 flag congo brazzaville congo flag nation country banner congo brazzaville
+🇨🇭 flag switzerland ch flag nation country banner switzerland
+🇨🇮 flag cote d ivoire ivory coast flag nation country banner cote d ivoire
+🇨🇰 flag cook islands cook islands flag nation country banner cook islands
+🇨🇱 flag chile flag nation country banner chile
+🇨🇲 flag cameroon cm flag nation country banner cameroon
+🇨🇳 flag china china chinese prc flag country nation banner china
+🇨🇴 flag colombia co flag nation country banner colombia
+🇨🇵 flag clipperton island
+🇨🇷 flag costa rica costa rica flag nation country banner costa rica
+🇨🇺 flag cuba cu flag nation country banner cuba
+🇨🇻 flag cape verde cabo verde flag nation country banner cape verde
+🇨🇼 flag curacao curaçao flag nation country banner curacao
+🇨🇽 flag christmas island christmas island flag nation country banner christmas island
+🇨🇾 flag cyprus cy flag nation country banner cyprus
+🇨🇿 flag czechia cz flag nation country banner czechia
+🇩🇪 flag germany german nation flag country banner germany
+🇩🇬 flag diego garcia
+🇩🇯 flag djibouti dj flag nation country banner djibouti
+🇩🇰 flag denmark dk flag nation country banner denmark
+🇩🇲 flag dominica dm flag nation country banner dominica
+🇩🇴 flag dominican republic dominican republic flag nation country banner dominican republic
+🇩🇿 flag algeria dz flag nation country banner algeria
+🇪🇦 flag ceuta melilla
+🇪🇨 flag ecuador ec flag nation country banner ecuador
+🇪🇪 flag estonia ee flag nation country banner estonia
+🇪🇬 flag egypt eg flag nation country banner egypt
+🇪🇭 flag western sahara western sahara flag nation country banner western sahara
+🇪🇷 flag eritrea er flag nation country banner eritrea
+🇪🇸 flag spain spain flag nation country banner spain
+🇪🇹 flag ethiopia et flag nation country banner ethiopia
+🇪🇺 flag european union european union flag banner
+🇫🇮 flag finland fi flag nation country banner finland
+🇫🇯 flag fiji fj flag nation country banner fiji
+🇫🇰 flag falkland islands falkland islands malvinas flag nation country banner falkland islands
+🇫🇲 flag micronesia micronesia federated states flag nation country banner micronesia
+🇫🇴 flag faroe islands faroe islands flag nation country banner faroe islands
+🇫🇷 flag france banner flag nation france french country france
+🇬🇦 flag gabon ga flag nation country banner gabon
+🇬🇧 flag united kingdom united kingdom great britain northern ireland flag nation country banner british UK english england union jack united kingdom
+🇬🇩 flag grenada gd flag nation country banner grenada
+🇬🇪 flag georgia ge flag nation country banner georgia
+🇬🇫 flag french guiana french guiana flag nation country banner french guiana
+🇬🇬 flag guernsey gg flag nation country banner guernsey
+🇬🇭 flag ghana gh flag nation country banner ghana
+🇬🇮 flag gibraltar gi flag nation country banner gibraltar
+🇬🇱 flag greenland gl flag nation country banner greenland
+🇬🇲 flag gambia gm flag nation country banner gambia
+🇬🇳 flag guinea gn flag nation country banner guinea
+🇬🇵 flag guadeloupe gp flag nation country banner guadeloupe
+🇬🇶 flag equatorial guinea equatorial gn flag nation country banner equatorial guinea
+🇬🇷 flag greece gr flag nation country banner greece
+🇬🇸 flag south georgia south sandwich islands south georgia sandwich islands flag nation country banner south georgia south sandwich islands
+🇬🇹 flag guatemala gt flag nation country banner guatemala
+🇬🇺 flag guam gu flag nation country banner guam
+🇬🇼 flag guinea bissau gw bissau flag nation country banner guinea bissau
+🇬🇾 flag guyana gy flag nation country banner guyana
+🇭🇰 flag hong kong sar china hong kong flag nation country banner hong kong sar china
+🇭🇲 flag heard mcdonald islands
+🇭🇳 flag honduras hn flag nation country banner honduras
+🇭🇷 flag croatia hr flag nation country banner croatia
+🇭🇹 flag haiti ht flag nation country banner haiti
+🇭🇺 flag hungary hu flag nation country banner hungary
+🇮🇨 flag canary islands canary islands flag nation country banner canary islands
+🇮🇩 flag indonesia flag nation country banner indonesia
+🇮🇪 flag ireland ie flag nation country banner ireland
+🇮🇱 flag israel il flag nation country banner israel
+🇮🇲 flag isle of man isle man flag nation country banner isle of man
+🇮🇳 flag india in flag nation country banner india
+🇮🇴 flag british indian ocean territory british indian ocean territory flag nation country banner british indian ocean territory
+🇮🇶 flag iraq iq flag nation country banner iraq
+🇮🇷 flag iran iran islamic republic flag nation country banner iran
+🇮🇸 flag iceland is flag nation country banner iceland
+🇮🇹 flag italy italy flag nation country banner italy
+🇯🇪 flag jersey je flag nation country banner jersey
+🇯🇲 flag jamaica jm flag nation country banner jamaica
+🇯🇴 flag jordan jo flag nation country banner jordan
+🇯🇵 flag japan japanese nation flag country banner japan
+🇰🇪 flag kenya ke flag nation country banner kenya
+🇰🇬 flag kyrgyzstan kg flag nation country banner kyrgyzstan
+🇰🇭 flag cambodia kh flag nation country banner cambodia
+🇰🇮 flag kiribati ki flag nation country banner kiribati
+🇰🇲 flag comoros km flag nation country banner comoros
+🇰🇳 flag st kitts nevis saint kitts nevis flag nation country banner st kitts nevis
+🇰🇵 flag north korea north korea nation flag country banner north korea
+🇰🇷 flag south korea south korea nation flag country banner south korea
+🇰🇼 flag kuwait kw flag nation country banner kuwait
+🇰🇾 flag cayman islands cayman islands flag nation country banner cayman islands
+🇰🇿 flag kazakhstan kz flag nation country banner kazakhstan
+🇱🇦 flag laos lao democratic republic flag nation country banner laos
+🇱🇧 flag lebanon lb flag nation country banner lebanon
+🇱🇨 flag st lucia saint lucia flag nation country banner st lucia
+🇱🇮 flag liechtenstein li flag nation country banner liechtenstein
+🇱🇰 flag sri lanka sri lanka flag nation country banner sri lanka
+🇱🇷 flag liberia lr flag nation country banner liberia
+🇱🇸 flag lesotho ls flag nation country banner lesotho
+🇱🇹 flag lithuania lt flag nation country banner lithuania
+🇱🇺 flag luxembourg lu flag nation country banner luxembourg
+🇱🇻 flag latvia lv flag nation country banner latvia
+🇱🇾 flag libya ly flag nation country banner libya
+🇲🇦 flag morocco ma flag nation country banner morocco
+🇲🇨 flag monaco mc flag nation country banner monaco
+🇲🇩 flag moldova moldova republic flag nation country banner moldova
+🇲🇪 flag montenegro me flag nation country banner montenegro
+🇲🇫 flag st martin
+🇲🇬 flag madagascar mg flag nation country banner madagascar
+🇲🇭 flag marshall islands marshall islands flag nation country banner marshall islands
+🇲🇰 flag north macedonia macedonia flag nation country banner north macedonia
+🇲🇱 flag mali ml flag nation country banner mali
+🇲🇲 flag myanmar mm flag nation country banner myanmar
+🇲🇳 flag mongolia mn flag nation country banner mongolia
+🇲🇴 flag macao sar china macao flag nation country banner macao sar china
+🇲🇵 flag northern mariana islands northern mariana islands flag nation country banner northern mariana islands
+🇲🇶 flag martinique mq flag nation country banner martinique
+🇲🇷 flag mauritania mr flag nation country banner mauritania
+🇲🇸 flag montserrat ms flag nation country banner montserrat
+🇲🇹 flag malta mt flag nation country banner malta
+🇲🇺 flag mauritius mu flag nation country banner mauritius
+🇲🇻 flag maldives mv flag nation country banner maldives
+🇲🇼 flag malawi mw flag nation country banner malawi
+🇲🇽 flag mexico mx flag nation country banner mexico
+🇲🇾 flag malaysia my flag nation country banner malaysia
+🇲🇿 flag mozambique mz flag nation country banner mozambique
+🇳🇦 flag namibia na flag nation country banner namibia
+🇳🇨 flag new caledonia new caledonia flag nation country banner new caledonia
+🇳🇪 flag niger ne flag nation country banner niger
+🇳🇫 flag norfolk island norfolk island flag nation country banner norfolk island
+🇳🇬 flag nigeria flag nation country banner nigeria
+🇳🇮 flag nicaragua ni flag nation country banner nicaragua
+🇳🇱 flag netherlands nl flag nation country banner netherlands
+🇳🇴 flag norway no flag nation country banner norway
+🇳🇵 flag nepal np flag nation country banner nepal
+🇳🇷 flag nauru nr flag nation country banner nauru
+🇳🇺 flag niue nu flag nation country banner niue
+🇳🇿 flag new zealand new zealand flag nation country banner new zealand
+🇴🇲 flag oman om symbol flag nation country banner oman
+🇵🇦 flag panama pa flag nation country banner panama
+🇵🇪 flag peru pe flag nation country banner peru
+🇵🇫 flag french polynesia french polynesia flag nation country banner french polynesia
+🇵🇬 flag papua new guinea papua new guinea flag nation country banner papua new guinea
+🇵🇭 flag philippines ph flag nation country banner philippines
+🇵🇰 flag pakistan pk flag nation country banner pakistan
+🇵🇱 flag poland pl flag nation country banner poland
+🇵🇲 flag st pierre miquelon saint pierre miquelon flag nation country banner st pierre miquelon
+🇵🇳 flag pitcairn islands pitcairn flag nation country banner pitcairn islands
+🇵🇷 flag puerto rico puerto rico flag nation country banner puerto rico
+🇵🇸 flag palestinian territories palestine palestinian territories flag nation country banner palestinian territories
+🇵🇹 flag portugal pt flag nation country banner portugal
+🇵🇼 flag palau pw flag nation country banner palau
+🇵🇾 flag paraguay py flag nation country banner paraguay
+🇶🇦 flag qatar qa flag nation country banner qatar
+🇷🇪 flag reunion réunion flag nation country banner reunion
+🇷🇴 flag romania ro flag nation country banner romania
+🇷🇸 flag serbia rs flag nation country banner serbia
+🇷🇺 flag russia russian federation flag nation country banner russia
+🇷🇼 flag rwanda rw flag nation country banner rwanda
+🇸🇦 flag saudi arabia flag nation country banner saudi arabia
+🇸🇧 flag solomon islands solomon islands flag nation country banner solomon islands
+🇸🇨 flag seychelles sc flag nation country banner seychelles
+🇸🇩 flag sudan sd flag nation country banner sudan
+🇸🇪 flag sweden se flag nation country banner sweden
+🇸🇬 flag singapore sg flag nation country banner singapore
+🇸🇭 flag st helena saint helena ascension tristan cunha flag nation country banner st helena
+🇸🇮 flag slovenia si flag nation country banner slovenia
+🇸🇯 flag svalbard jan mayen
+🇸🇰 flag slovakia sk flag nation country banner slovakia
+🇸🇱 flag sierra leone sierra leone flag nation country banner sierra leone
+🇸🇲 flag san marino san marino flag nation country banner san marino
+🇸🇳 flag senegal sn flag nation country banner senegal
+🇸🇴 flag somalia so flag nation country banner somalia
+🇸🇷 flag suriname sr flag nation country banner suriname
+🇸🇸 flag south sudan south sd flag nation country banner south sudan
+🇸🇹 flag sao tome principe sao tome principe flag nation country banner sao tome principe
+🇸🇻 flag el salvador el salvador flag nation country banner el salvador
+🇸🇽 flag sint maarten sint maarten dutch flag nation country banner sint maarten
+🇸🇾 flag syria syrian arab republic flag nation country banner syria
+🇸🇿 flag eswatini sz flag nation country banner eswatini
+🇹🇦 flag tristan da cunha
+🇹🇨 flag turks caicos islands turks caicos islands flag nation country banner turks caicos islands
+🇹🇩 flag chad td flag nation country banner chad
+🇹🇫 flag french southern territories french southern territories flag nation country banner french southern territories
+🇹🇬 flag togo tg flag nation country banner togo
+🇹🇭 flag thailand th flag nation country banner thailand
+🇹🇯 flag tajikistan tj flag nation country banner tajikistan
+🇹🇰 flag tokelau tk flag nation country banner tokelau
+🇹🇱 flag timor leste timor leste flag nation country banner timor leste
+🇹🇲 flag turkmenistan flag nation country banner turkmenistan
+🇹🇳 flag tunisia tn flag nation country banner tunisia
+🇹🇴 flag tonga to flag nation country banner tonga
+🇹🇷 flag turkey turkey flag nation country banner turkey
+🇹🇹 flag trinidad tobago trinidad tobago flag nation country banner trinidad tobago
+🇹🇻 flag tuvalu flag nation country banner tuvalu
+🇹🇼 flag taiwan tw flag nation country banner taiwan
+🇹🇿 flag tanzania tanzania united republic flag nation country banner tanzania
+🇺🇦 flag ukraine ua flag nation country banner ukraine
+🇺🇬 flag uganda ug flag nation country banner uganda
+🇺🇲 flag u s outlying islands
+🇺🇳 flag united nations un flag banner
+🇺🇸 flag united states united states america flag nation country banner united states
+🇺🇾 flag uruguay uy flag nation country banner uruguay
+🇺🇿 flag uzbekistan uz flag nation country banner uzbekistan
+🇻🇦 flag vatican city vatican city flag nation country banner vatican city
+🇻🇨 flag st vincent grenadines saint vincent grenadines flag nation country banner st vincent grenadines
+🇻🇪 flag venezuela ve bolivarian republic flag nation country banner venezuela
+🇻🇬 flag british virgin islands british virgin islands bvi flag nation country banner british virgin islands
+🇻🇮 flag u s virgin islands virgin islands us flag nation country banner u s virgin islands
+🇻🇳 flag vietnam viet nam flag nation country banner vietnam
+🇻🇺 flag vanuatu vu flag nation country banner vanuatu
+🇼🇫 flag wallis futuna wallis futuna flag nation country banner wallis futuna
+🇼🇸 flag samoa ws flag nation country banner samoa
+🇽🇰 flag kosovo xk flag nation country banner kosovo
+🇾🇪 flag yemen ye flag nation country banner yemen
+🇾🇹 flag mayotte yt flag nation country banner mayotte
+🇿🇦 flag south africa south africa flag nation country banner south africa
+🇿🇲 flag zambia zm flag nation country banner zambia
+🇿🇼 flag zimbabwe zw flag nation country banner zimbabwe
+🏴󠁧󠁢󠁥󠁮󠁧󠁿 flag england flag english
+🏴󠁧󠁢󠁳󠁣󠁴󠁿 flag scotland flag scottish
+🏴󠁧󠁢󠁷󠁬󠁳󠁿 flag wales flag welsh
 🥲 smiling face with tear sad cry pretend
 🥸 disguised face pretent brows glasses moustache
 🤌 pinched fingers size tiny small


### PR DESCRIPTION
16cd55577a05e32442dd76fba3f10deaca4a8bb6 introduced alternative keywords
which is great, but some of those keywords are using an underscore as a
separator which is inconvenient. For example, searching for "party
popper" doesn't show the "🎉" emoji as its name is "party_popper".

This commit prevents this by replacing any underscore by a space.