### PR TITLE
Using wtype if it's available, otherwise uses wl-clipboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # wofi-emoji 🥞
 
-Simple emoji selector for Wayland using [wofi](https://cloudninja.pw/docs/wofi.html) and [wtype](https://github.com/atx/wtype).
+Simple emoji selector for Wayland using [wofi](https://cloudninja.pw/docs/wofi.html).
+It relies on [wtype](https://github.com/atx/wtype) when it's supported, otherwise,
+[wl-clipboard](https://github.com/bugaevc/wl-clipboard) is used instead.
 
 ![Screenshot of wofi-emoji in action](https://i.imgur.com/8XiUoh6.png)
 

--- a/wofi-emoji
+++ b/wofi-emoji
@@ -1,5 +1,11 @@
 #!/bin/bash
-sed '1,/^### DATA ###$/d' $0 | wofi --show dmenu -i | cut -d ' ' -f 1 | tr -d '\n' | wtype -
+wtype 0
+if [ $? -eq 0 ]
+then
+    sed '1,/^### DATA ###$/d' $0 | wofi --show dmenu -i | cut -d ' ' -f 1 | tr -d '\n' | wtype -
+else
+    sed '1,/^### DATA ###$/d' $0 | wofi --show dmenu -i | cut -d ' ' -f 1 | tr -d '\n' | wl-copy
+fi
 exit
 ### DATA ###
 😀 grinning_face face smile happy joy :D grin


### PR DESCRIPTION
As mentioned in #8, wtype doesn't work for Gnome just yet, so we will be using wl-clipboard as a backup plan.