### PR TITLE
fix: don't type character "0" to check if wtype works

### DIFF
--- a/wofi-emoji
+++ b/wofi-emoji
@@ -1,11 +1,6 @@
 #!/bin/bash
-wtype 0
-if [ $? -eq 0 ]
-then
-    sed '1,/^### DATA ###$/d' $0 | wofi --show dmenu -i | cut -d ' ' -f 1 | tr -d '\n' | wtype -
-else
-    sed '1,/^### DATA ###$/d' $0 | wofi --show dmenu -i | cut -d ' ' -f 1 | tr -d '\n' | wl-copy
-fi
+emoji="$(sed '1,/^### DATA ###$/d' $0 | wofi --show dmenu -i | cut -d ' ' -f 1 | tr -d '\n')"
+wtype "${emoji}" || wl-copy "${emoji}"
 exit
 ### DATA ###
 😀 grinning face face smile happy joy :D grin

--- a/wofi-emoji
+++ b/wofi-emoji
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -euo pipefail
+
 emoji="$(sed '1,/^### DATA ###$/d' $0 | wofi --show dmenu -i | cut -d ' ' -f 1 | tr -d '\n')"
 wtype "${emoji}" || wl-copy "${emoji}"
 exit


### PR DESCRIPTION
87e5582463f1cb323f5ba809bfe8f1e69a8b2b90 (#9) added a fallback to
wl-clipboard when wtype isn't supported in the current environment. To
do so, they invoked "wtype 0" to check whether wtype works.
Unfortunately, this leads to inconsistent and buggy behaviors: sometimes
the character "0" gets typed, and sometimes the current window loses
focus (at least on my config).

As there doesn't seem to be a way to know in advance if wtype will work
without invoking it, this commit workarounds this issue by adopting the
"EAFP" principle, trying to use wtype with the emoji directly, and only
if it didn't work, invoke wl-copy.